### PR TITLE
Concurrency issue

### DIFF
--- a/oai_server_benchmark.py
+++ b/oai_server_benchmark.py
@@ -276,9 +276,7 @@ def run_multiprocess_benchmark(conversations: List[List[Dict]], api_base: str, m
     # Calculate max concurrent connections per process
     # Use a reasonable limit per process to avoid overwhelming the system
     max_concurrent_per_process = max(1, conversations_per_process + 1)
-    
-    print(f"Using {actual_cores} processes, {conversations_per_process}-{conversations_per_process+1} conversations per process")
-    print(f"Max concurrent per process: {max_concurrent_per_process}")
+
     
     result_queue = multiprocessing.Queue(maxsize=actual_cores * 2)
     
@@ -394,9 +392,6 @@ async def main():
         },
         "results": {}
     }
-
-    print(f"Starting multiprocess async benchmark for model: {args.model}")
-    print(f"Using {args.n_cores} processes")
     
     for batch_size in batch_sizes:
         print(f"\n=== Benchmarking Batch Size: {batch_size} ===")

--- a/oai_server_benchmark.py
+++ b/oai_server_benchmark.py
@@ -64,17 +64,26 @@ class AsyncBenchmark:
         connector = aiohttp.TCPConnector(
             limit=self.max_batch_size,  
             limit_per_host=self.max_batch_size,
-            ttl_dns_cache=300,  # DNS cache TTL
+            ttl_dns_cache=10,  # DNS cache TTL
             use_dns_cache=True,
-            keepalive_timeout=30,
+            keepalive_timeout=0,
             enable_cleanup_closed=True
         )
         
-        timeout = aiohttp.ClientTimeout(total=self.max_batch_size)
+        timeout = aiohttp.ClientTimeout(
+            total=300,  # Total request timeout
+            connect=30,  # Connection establishment timeout
+            sock_read=60,  # Individual socket read timeout
+            sock_connect=10  # Socket connection timeout
+        )
 
+        # Use large read buffer (10MB) like sglang for handling large responses
+        read_bufsize = 10 * 1024 * 1024  # 10 MB buffer
+        
         return aiohttp.ClientSession(
             connector=connector,
             timeout=timeout,
+            read_bufsize=read_bufsize,
             headers={"Authorization": "Bearer sk-dummy"}
         )
     

--- a/oai_server_benchmark.py
+++ b/oai_server_benchmark.py
@@ -74,9 +74,8 @@ class AsyncBenchmark:
         )
         
         timeout = aiohttp.ClientTimeout(
-            total=300,  # Total request timeout
+            total=1800,  # Total request timeout
             connect=30,  # Connection establishment timeout
-            sock_read=60,  # Individual socket read timeout
             sock_connect=10  # Socket connection timeout
         )
 
@@ -293,7 +292,7 @@ def run_multiprocess_benchmark(conversations: List[List[Dict]], api_base: str, m
     worker_results = []
     for _ in range(actual_cores):
         try:
-            result = result_queue.get(timeout=600)  # 10 minute timeout per process
+            result = result_queue.get(timeout=1800)  # 30 minute timeout per process
             if result is not None:
                 worker_results.append(result)
         except:
@@ -301,7 +300,7 @@ def run_multiprocess_benchmark(conversations: List[List[Dict]], api_base: str, m
     
     # Now wait for all processes to complete
     for p in processes:
-        p.join(timeout=600)  # 10 minute timeout per process
+        p.join(timeout=1800)  # 30 minute timeout per process
         if p.is_alive():
             print(f"Warning: Process {p.pid} didn't finish in time, terminating")
             p.terminate()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+-r test/requirements.txt
 datasets==3.2.0 
 openai
 matplotlib
 seaborn
+aiohttp

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,58 @@
+# FastAPI Test Server for OpenAI Chat Completions API
+
+A lightweight FastAPI server that mimics OpenAI's chat completions API for testing and benchmarking.
+
+## Quick Start
+
+```bash
+pip install fastapi uvicorn
+python test_server.py
+```
+
+## Usage
+
+### Basic Usage
+```bash
+python test_server.py
+```
+
+### With Custom Configuration
+```bash
+python test_server.py --host 0.0.0.0 --port 8001 --prompt-tokens 100 --completion-tokens 150 --timeout 2.0
+```
+
+#### Single worker (recommended for async)
+```bash
+python test_server.py --port 8000 --workers 1 --timeout 5.0
+```
+
+#### Multiple workers (for CPU-bound tasks)
+```bash
+python test_server.py --port 8000 --workers 4 --timeout 5.0
+```
+
+### Options
+- `--host`: Host to bind to (default: 127.0.0.1)
+- `--port`: Port to bind to (default: 8000)
+- `--prompt-tokens`: Fixed prompt tokens to return (default: 50)
+- `--completion-tokens`: Fixed completion tokens to return (default: 75)
+- `--timeout`: Request timeout in seconds (default: 5.0)
+- `--workers`: Number of worker processes (default: 1)
+- `--reload`: Enable auto-reload for development
+
+## API Endpoints
+
+- `POST /v1/chat/completions` - OpenAI-compatible chat completions
+- `GET /v1/models` - List available models
+- `GET /health` - Health check with concurrency stats
+- `GET /stats` - Detailed server statistics
+
+## Testing
+
+```bash
+# Test with benchmark script
+python ../oai_server_benchmark.py --model test-model --api_base http://127.0.0.1:8000/v1
+
+# View documentation
+curl http://127.0.0.1:8000/docs
+``` 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+Simplified FastAPI test server that mimics OpenAI chat completions API
+for testing the benchmark script with high concurrency support.
+"""
+
+import time
+import asyncio
+import argparse
+import threading
+from datetime import datetime
+from typing import Dict, List, Any
+from fastapi import FastAPI, HTTPException
+import uvicorn
+
+# Configuration variables
+FIXED_PROMPT_TOKENS = 50
+FIXED_COMPLETION_TOKENS = 75
+REQUEST_TIMEOUT = 5.0  # seconds
+
+# Statistics tracking (thread-safe)
+request_stats = {
+    'total_requests': 0,
+    'concurrent_requests': 0,
+    'max_concurrent': 0,
+    'lock': threading.Lock()
+}
+
+# Create FastAPI app
+app = FastAPI(title="OpenAI Chat Completions Test Server")
+
+def update_stats(increment=True):
+    """Update request statistics thread-safely"""
+    with request_stats['lock']:
+        if increment:
+            request_stats['total_requests'] += 1
+            request_stats['concurrent_requests'] += 1
+            request_stats['max_concurrent'] = max(
+                request_stats['max_concurrent'], 
+                request_stats['concurrent_requests']
+            )
+        else:
+            request_stats['concurrent_requests'] -= 1
+
+@app.post("/v1/chat/completions")
+async def chat_completions(request: Dict[str, Any]):
+    """
+    Mimics OpenAI's chat completions endpoint with async processing.
+    """
+    try:
+        update_stats(increment=True)
+        
+        # Extract parameters
+        messages = request.get('messages', [])
+        model = request.get('model', 'test-model')
+        
+        # Non-blocking delay
+        await asyncio.sleep(REQUEST_TIMEOUT)
+        
+        # Generate response
+        if messages:
+            last_message = messages[-1].get('content', 'Hello!')
+            response_content = f"Test response to: {last_message[:50]}..."
+        else:
+            response_content = "Test response with no input message."
+        
+        # Generate unique request ID
+        request_id = f"{int(time.time())}-{id(request)}"
+        
+        # Create OpenAI-compatible response
+        response = {
+            "id": f"chatcmpl-test-{request_id}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": response_content
+                    },
+                    "finish_reason": "stop"
+                }
+            ],
+            "usage": {
+                "prompt_tokens": FIXED_PROMPT_TOKENS,
+                "completion_tokens": FIXED_COMPLETION_TOKENS,
+                "total_tokens": FIXED_PROMPT_TOKENS + FIXED_COMPLETION_TOKENS
+            }
+        }
+        
+        return response
+        
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    finally:
+        update_stats(increment=False)
+
+@app.get("/v1/models")
+async def list_models():
+    """List available models."""
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": "test-model",
+                "object": "model",
+                "created": int(time.time()),
+                "owned_by": "test-server"
+            }
+        ]
+    }
+
+@app.get("/health")
+async def health_check():
+    """Health check endpoint with concurrency statistics."""
+    with request_stats['lock']:
+        return {
+            "status": "healthy",
+            "timestamp": datetime.now().isoformat(),
+            "config": {
+                "prompt_tokens": FIXED_PROMPT_TOKENS,
+                "completion_tokens": FIXED_COMPLETION_TOKENS,
+                "timeout_seconds": REQUEST_TIMEOUT
+            },
+            "statistics": {
+                "total_requests": request_stats['total_requests'],
+                "concurrent_requests": request_stats['concurrent_requests'],
+                "max_concurrent_reached": request_stats['max_concurrent']
+            }
+        }
+
+@app.get("/stats")
+async def get_stats():
+    """Get detailed statistics about server performance."""
+    with request_stats['lock']:
+        return {
+            "total_requests_processed": request_stats['total_requests'],
+            "currently_processing": request_stats['concurrent_requests'],
+            "max_concurrent_reached": request_stats['max_concurrent'],
+            "active_threads": threading.active_count()
+        }
+
+def main():
+    parser = argparse.ArgumentParser(description='Simplified FastAPI test server for OpenAI chat completions API')
+    parser.add_argument('--host', default='127.0.0.1', help='Host to bind to')
+    parser.add_argument('--port', type=int, default=8000, help='Port to bind to')
+    parser.add_argument('--prompt-tokens', type=int, default=50, help='Fixed prompt tokens to return')
+    parser.add_argument('--completion-tokens', type=int, default=75, help='Fixed completion tokens to return')
+    parser.add_argument('--timeout', type=float, default=5.0, help='Request timeout in seconds')
+    parser.add_argument('--workers', type=int, default=1, help='Number of worker processes')
+    parser.add_argument('--reload', action='store_true', help='Enable auto-reload for development')
+    
+    args = parser.parse_args()
+    
+    # Update global configuration
+    global FIXED_PROMPT_TOKENS, FIXED_COMPLETION_TOKENS, REQUEST_TIMEOUT
+    FIXED_PROMPT_TOKENS = args.prompt_tokens
+    FIXED_COMPLETION_TOKENS = args.completion_tokens
+    REQUEST_TIMEOUT = args.timeout
+    
+    print(f"Starting FastAPI test server...")
+    print(f"Host: {args.host}:{args.port}")
+    print(f"Fixed prompt tokens: {FIXED_PROMPT_TOKENS}")
+    print(f"Fixed completion tokens: {FIXED_COMPLETION_TOKENS}")
+    print(f"Request timeout: {REQUEST_TIMEOUT}s")
+    print(f"API Base URL: http://{args.host}:{args.port}/v1")
+    print(f"Documentation: http://{args.host}:{args.port}/docs")
+    
+    try:
+        uvicorn.run(
+            "test_server:app",
+            host=args.host,
+            port=args.port,
+            workers=args.workers,
+            reload=args.reload
+        )
+    except KeyboardInterrupt:
+        print("\nShutting down server...")
+
+if __name__ == '__main__':
+    main()

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -170,7 +170,7 @@ def main():
     
     try:
         uvicorn.run(
-            "test_server:app",
+            app,
             host=args.host,
             port=args.port,
             workers=args.workers,


### PR DESCRIPTION
1. Create a test server with a fixed timeout to measure the overhead of the concurrent requests.
2. Optimise the concurrency of the benchmark script by creating up to 512 async requests per process and scale the processes to accommodate all requests. This solves the concurrency issue and has minimal overhead (roughly 0.4s with 8k concurrent requests instead of 6x as before)