### PR TITLE
Deterministic sampling: derive per-run seeds

### DIFF
--- a/sampling/__init__.py
+++ b/sampling/__init__.py
@@ -6,7 +6,7 @@ statistical parameter generation from content sampling.
 """
 
 from .scenarios import Scenario, NormalDistribution, DeterministicDistribution, UniformDistribution
-from .sampler import TextSampler, BatchSampler
+from .sampler import TextSampler, BatchSampler, use_seed, derive_seed
 from .dataset import DatasetConfig, DatasetLoader
 
 __all__ = [
@@ -16,6 +16,8 @@ __all__ = [
     'UniformDistribution',
     'TextSampler',
     'BatchSampler',
+    'use_seed',
+    'derive_seed',
     'DatasetConfig',
     'DatasetLoader'
 ]


### PR DESCRIPTION
This gives different prompts per run, reproducible across invocations for the same base seed and batch size.