### PR TITLE
benchmark: add refill-loop steady-state mode + robust TTFT/TPOT

### DIFF
--- a/completion_advanced_benchmark.py
+++ b/completion_advanced_benchmark.py
@@ -85,12 +85,164 @@ class LoRAConfig:
         return self._apply_base_model_ratio(raw_assignments)
 
 
+async def _iter_sse_data(stream) -> str:
+    """Yield concatenated SSE data payloads, robust to chunk boundaries."""
+    buffer = ""
+    event_data_lines: List[str] = []
+
+    async for chunk in stream.iter_any():
+        if not chunk:
+            continue
+        buffer += chunk.decode("utf-8", errors="replace")
+        while "\n" in buffer:
+            raw_line, buffer = buffer.split("\n", 1)
+            line = raw_line.rstrip("\r")
+
+            if line == "":
+                if event_data_lines:
+                    yield "\n".join(event_data_lines)
+                    event_data_lines = []
+                continue
+
+            if line.startswith(":"):
+                continue
+            if line.startswith("data:"):
+                event_data_lines.append(line[5:].lstrip())
+
+    if event_data_lines:
+        yield "\n".join(event_data_lines)
+
+
+def _extract_text_from_delta(delta: Dict[str, Any]) -> str:
+    """Extract streamed text from common delta layouts."""
+    pieces: List[str] = []
+    for key in ("reasoning_content", "content", "text", "reasoning", "output_text"):
+        value = delta.get(key)
+        if isinstance(value, str):
+            pieces.append(value)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, str):
+                    pieces.append(item)
+                elif isinstance(item, dict):
+                    for sub_key in ("reasoning_content", "content", "text", "output_text"):
+                        sub_val = item.get(sub_key)
+                        if isinstance(sub_val, str):
+                            pieces.append(sub_val)
+    return "".join(pieces)
+
+
+def _summarize_run_results(results: List[Dict[str, Any]], total_requests: int, batch_total_seconds: float) -> Dict:
+    """Summarize per-request results for one run window."""
+    successful_results = [r for r in results if r.get("success", False)]
+    failed_results = [r for r in results if not r.get("success", False)]
+    success_count = len(successful_results)
+    failure_count = len(failed_results)
+
+    if not successful_results:
+        return {
+            "tokens": {"input_per_request": [], "output_per_request": []},
+            "timings": {"batch_total_seconds": batch_total_seconds, "fastest_seconds": 0, "slowest_seconds": 0, "spread_seconds": 0},
+            "prefill_metrics": {
+                "ttft_per_request": [],
+                "input_throughput_per_request": [],
+                "ttft_missing_count": 0,
+            },
+            "decode_metrics": {"output_throughput_per_request": [], "tpot_per_request": [], "decode_time_per_request": []},
+            "batch_metrics": {
+                "total_input_tokens": 0,
+                "total_output_tokens": 0,
+                "total_tokens": 0,
+                "batch_duration": batch_total_seconds,
+                "total_token_throughput": 0,
+                "output_token_throughput": 0,
+                "combined_decode_throughput_sum": 0,
+                "combined_throughput": 0,
+                "total_requests": 0,
+            },
+            "failures": {"total_requests": total_requests, "successful": success_count, "failed": failure_count}
+        }
+
+    input_tokens = [r["input_tokens"] for r in successful_results]
+    output_tokens = [r["output_tokens"] for r in successful_results]
+
+    ttft_values = [r.get("ttft", 0) for r in successful_results if r.get("ttft", 0) > 0]
+    ttft_missing_count = max(0, len(successful_results) - len(ttft_values))
+    input_throughput_values = [r.get("input_throughput", 0) for r in successful_results if r.get("input_throughput", 0) > 0]
+    output_throughput_values = [r.get("output_throughput", 0) for r in successful_results if r.get("output_throughput", 0) > 0]
+    tpot_values = [r.get("tpot", 0) for r in successful_results if r.get("tpot", 0) > 0]
+    decode_time_values = [r.get("decode_time", 0) for r in successful_results if r.get("decode_time", 0) > 0]
+
+    lora_names = [r.get("lora_name") for r in successful_results]
+    unique_loras = set(lora_names) - {None}
+    base_model_count = lora_names.count(None)
+
+    relative_ends = [r["relative_end"] for r in successful_results]
+    fastest_seconds = min(relative_ends)
+    slowest_seconds = max(relative_ends)
+    spread_seconds = slowest_seconds - fastest_seconds
+
+    total_input_tokens = sum(input_tokens)
+    total_output_tokens = sum(output_tokens)
+    total_tokens = total_input_tokens + total_output_tokens
+    total_token_throughput = total_tokens / batch_total_seconds if batch_total_seconds > 0 else 0
+    output_token_throughput = total_output_tokens / batch_total_seconds if batch_total_seconds > 0 else 0
+    decode_throughput_sum = sum(output_throughput_values)
+
+    return {
+        "tokens": {
+            "input_per_request": input_tokens,
+            "output_per_request": output_tokens
+        },
+        "timings": {
+            "batch_total_seconds": batch_total_seconds,
+            "fastest_seconds": fastest_seconds,
+            "slowest_seconds": slowest_seconds,
+            "spread_seconds": spread_seconds
+        },
+        "prefill_metrics": {
+            "ttft_per_request": ttft_values,
+            "input_throughput_per_request": input_throughput_values,
+            "ttft_missing_count": ttft_missing_count,
+        },
+        "decode_metrics": {
+            "output_throughput_per_request": output_throughput_values,
+            "tpot_per_request": tpot_values,
+            "decode_time_per_request": decode_time_values
+        },
+        "batch_metrics": {
+            "total_input_tokens": total_input_tokens,
+            "total_output_tokens": total_output_tokens,
+            "total_tokens": total_tokens,
+            "batch_duration": batch_total_seconds,
+            "total_token_throughput": total_token_throughput,
+            "output_token_throughput": output_token_throughput,
+            "combined_decode_throughput_sum": decode_throughput_sum,
+            "combined_throughput": total_token_throughput,
+            "total_requests": len(successful_results)
+        },
+        "failures": {
+            "total_requests": total_requests,
+            "successful": success_count,
+            "failed": failure_count
+        },
+        "lora_metrics": {
+            "lora_names_per_request": lora_names,
+            "unique_loras_count": len(unique_loras),
+            "unique_loras": list(unique_loras),
+            "base_model_count": base_model_count,
+            "base_model_percentage": (base_model_count / len(successful_results) * 100) if successful_results else 0
+        }
+    }
+
+
 async def single_request(session: aiohttp.ClientSession, api_base: str, model: str,
                         request_data: Dict[str, Any], temperature: float,
                         timeout: int, start_time: float, tokenizer=None) -> Dict:
     """Make a single API request with TTFT timing (streaming enabled)."""
     request_start = time.time()
     time_at_first_token = None
+    first_choice_time = None
     generated_text = ""
 
     # Extract max_tokens and optional LoRA name from request_data
@@ -126,43 +278,37 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
         ) as response:
             
             if response.status == 200:
-                # Process streaming response to capture TTFT and exact usage
+                # Process streaming response to capture TTFT and exact usage.
                 api_usage = None
                 
-                async for line in response.content:
-                    line_text = line.decode('utf-8').strip()
-                    
-                    if line_text.startswith('data: '):
-                        data_text = line_text[6:]  # Remove 'data: ' prefix
-                        
-                        if data_text == '[DONE]':
-                            break
-                        
-                        try:
-                            chunk_data = json.loads(data_text)
-                            choices = chunk_data.get('choices', [])
-                            
-                            
-                            if 'usage' in chunk_data:
-                                api_usage = chunk_data['usage']
-                            
-                            # Process content from choices
-                            if choices:
-                                delta = choices[0].get('delta', {})
-                                text = ''.join(x for x in (delta.get('reasoning_content'), delta.get('content')) if x)
-                                
-                                if text.strip() and time_at_first_token is None:
-                                    time_at_first_token = time.time()
-                                                                
-                                if text:
-                                    generated_text += text
-                                    
-                        except json.JSONDecodeError:
-                            continue  # Skip invalid JSON chunks
+                async for data_text in _iter_sse_data(response.content):
+                    if data_text == '[DONE]':
+                        break
+                    try:
+                        chunk_data = json.loads(data_text)
+                    except json.JSONDecodeError:
+                        continue
+
+                    choices = chunk_data.get('choices', [])
+                    if 'usage' in chunk_data:
+                        api_usage = chunk_data['usage']
+
+                    if choices:
+                        if first_choice_time is None:
+                            first_choice_time = time.time()
+                        delta = choices[0].get('delta', {}) or {}
+                        text = _extract_text_from_delta(delta)
+
+                        # Set TTFT on first meaningful generation delta.
+                        has_token_event = bool(text) or bool(delta.get("tool_calls")) or bool(delta.get("function_call"))
+                        if has_token_event and time_at_first_token is None:
+                            time_at_first_token = time.time()
+                        if text:
+                            generated_text += text
                 
                 request_end = time.time()
                 
-                # Calculate TTFT-based metrics
+                # Calculate TTFT-based metrics.
                 ttft = time_at_first_token - request_start if time_at_first_token else 0
                 e2e_latency = request_end - request_start
                 output_latency = e2e_latency - ttft if ttft > 0 else e2e_latency
@@ -183,6 +329,12 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
                     else:
                         output_tokens = int(len(generated_text.split()) * 1.3) if generated_text else 0
                     print(f"⚠️  No API usage info - using tokenizer fallback for output tokens")
+
+                # Fallback for providers/models that emit no text-bearing deltas before completion.
+                if time_at_first_token is None and first_choice_time is not None and output_tokens > 0:
+                    time_at_first_token = first_choice_time
+                    ttft = time_at_first_token - request_start
+                    output_latency = e2e_latency - ttft if ttft > 0 else e2e_latency
                 
                 input_throughput = input_tokens / ttft if ttft > 0 else 0
                 output_throughput = (output_tokens - 1) / output_latency if output_latency > 0 and output_tokens > 1 else 0
@@ -236,93 +388,94 @@ async def run_batch_async(user_requests: List[Dict], api_base: str, model: str, 
     
     end_time = time.time()
     batch_total_seconds = end_time - start_time
-    
-    # Process results and track failures
-    successful_results = [r for r in results if r.get("success", False)]
-    failed_results = [r for r in results if not r.get("success", False)]
-    
+    return _summarize_run_results(results, total_requests=len(user_requests), batch_total_seconds=batch_total_seconds)
+
+
+async def run_refill_async(user_requests: List[Dict], api_base: str, model: str, temperature: float,
+                           timeout: int, max_concurrent: int, tokenizer=None) -> Dict:
+    """Run requests with a refill loop to maintain steady concurrency."""
+
+    start_time = time.time()
+    results = []
     total_requests = len(user_requests)
-    success_count = len(successful_results)
-    failure_count = len(failed_results)
-    
-    # Don't print individual worker results here - aggregate them later
-    
-    if not successful_results:
-        return {
-            "tokens": {"input_per_request": [], "output_per_request": []},
-            "timings": {"batch_total_seconds": batch_total_seconds, "fastest_seconds": 0, "slowest_seconds": 0, "spread_seconds": 0},
-            "prefill_metrics": {"ttft_per_request": [], "input_throughput_per_request": []},
-            "decode_metrics": {"output_throughput_per_request": [], "tpot_per_request": []},
-            "batch_metrics": {"total_output_tokens": 0, "batch_duration": batch_total_seconds, "combined_throughput": 0, "total_requests": 0},
-            "failures": {"total_requests": total_requests, "successful": success_count, "failed": failure_count}
-        }
-    
-    # Extract original metrics
-    input_tokens = [r["input_tokens"] for r in successful_results]
-    output_tokens = [r["output_tokens"] for r in successful_results]
+    queue: asyncio.Queue = asyncio.Queue()
+    for req in user_requests:
+        queue.put_nowait(req)
 
-    # Extract TTFT-based metrics
-    ttft_values = [r.get("ttft", 0) for r in successful_results if r.get("ttft", 0) > 0]
-    input_throughput_values = [r.get("input_throughput", 0) for r in successful_results if r.get("input_throughput", 0) > 0]
-    output_throughput_values = [r.get("output_throughput", 0) for r in successful_results if r.get("output_throughput", 0) > 0]
-    tpot_values = [r.get("tpot", 0) for r in successful_results if r.get("tpot", 0) > 0]
-    decode_time_values = [r.get("decode_time", 0) for r in successful_results if r.get("decode_time", 0) > 0]
+    # Keep at most max_concurrent in-flight; refill as workers complete.
+    worker_count = min(max_concurrent, total_requests) if total_requests > 0 else 0
 
-    # Extract LoRA metrics
-    lora_names = [r.get("lora_name") for r in successful_results]
-    unique_loras = set(lora_names) - {None}
-    base_model_count = lora_names.count(None)
+    async with aiohttp.ClientSession() as session:
+        async def worker_loop():
+            while True:
+                try:
+                    request_data = queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    return
+                try:
+                    result = await single_request(
+                        session, api_base, model, request_data, temperature, timeout, start_time, tokenizer
+                    )
+                    results.append(result)
+                finally:
+                    queue.task_done()
 
-    # Calculate timing metrics (relative to batch start)
-    relative_ends = [r["relative_end"] for r in successful_results]
-    fastest_seconds = min(relative_ends)
-    slowest_seconds = max(relative_ends)
-    spread_seconds = slowest_seconds - fastest_seconds
+        workers = [asyncio.create_task(worker_loop()) for _ in range(worker_count)]
+        if workers:
+            await asyncio.gather(*workers)
 
+    end_time = time.time()
+    batch_total_seconds = end_time - start_time
+    return _summarize_run_results(results, total_requests=total_requests, batch_total_seconds=batch_total_seconds)
+
+
+def _truncate_prompt_to_cap(prompt: str, tokenizer, max_input_tokens: int) -> tuple[str, int]:
+    """Truncate prompt to at most max_input_tokens and return updated prompt/token count."""
+    if max_input_tokens <= 0:
+        try:
+            token_count = len(tokenizer.encode(prompt, add_special_tokens=False))
+        except Exception:
+            token_count = int(len(prompt.split()) * 1.3)
+        return prompt, token_count
+
+    try:
+        token_ids = tokenizer.encode(prompt, add_special_tokens=False)
+        if len(token_ids) <= max_input_tokens:
+            return prompt, len(token_ids)
+        truncated_ids = token_ids[:max_input_tokens]
+        truncated_prompt = tokenizer.decode(
+            truncated_ids,
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        )
+        return truncated_prompt, len(truncated_ids)
+    except Exception:
+        words = prompt.split()
+        approx_words = max(1, int(max_input_tokens / 1.3))
+        truncated_prompt = " ".join(words[:approx_words])
+        return truncated_prompt, int(len(truncated_prompt.split()) * 1.3)
+
+
+def build_request_dict(request, tokenizer, max_input_tokens_cap: int, max_output_tokens_cap: int) -> Dict[str, Any]:
+    """Build one request payload with optional hard caps for input/output token lengths."""
+    prompt, capped_input_tokens = _truncate_prompt_to_cap(
+        request.prompt,
+        tokenizer,
+        max_input_tokens_cap,
+    )
+
+    uncapped_output = int(request.target_output_tokens)
+    if max_output_tokens_cap > 0:
+        capped_output = min(uncapped_output, max_output_tokens_cap)
+    else:
+        capped_output = uncapped_output
+    capped_output = max(1, min(4096, capped_output))
 
     return {
-        "tokens": {
-            "input_per_request": input_tokens,
-            "output_per_request": output_tokens
-        },
-        "timings": {
-            "batch_total_seconds": batch_total_seconds,
-            "fastest_seconds": fastest_seconds,
-            "slowest_seconds": slowest_seconds,
-            "spread_seconds": spread_seconds
-        },
-        # Prefill phase metrics (input processing)
-        "prefill_metrics": {
-            "ttft_per_request": ttft_values,  # Time to first token
-            "input_throughput_per_request": input_throughput_values,  # Prefill speed
-        },
-        # Decode phase metrics (output generation)
-        "decode_metrics": {
-            "output_throughput_per_request": output_throughput_values,  # Decode speed per request
-            "tpot_per_request": tpot_values,  # Time per output token
-            "decode_time_per_request": decode_time_values  # Total time spent in decode phase per request
-        },
-        # Batch-level system metrics (combined performance)
-        "batch_metrics": {
-            "total_output_tokens": sum(output_tokens),
-            "batch_duration": batch_total_seconds,
-            "combined_throughput": sum(output_throughput_values),  # Sum of all individual decode speeds
-            "total_requests": len(successful_results)
-        },
-        # Request success/failure tracking
-        "failures": {
-            "total_requests": total_requests,
-            "successful": success_count,
-            "failed": failure_count
-        },
-        # LoRA-specific metrics
-        "lora_metrics": {
-            "lora_names_per_request": lora_names,
-            "unique_loras_count": len(unique_loras),
-            "unique_loras": list(unique_loras),
-            "base_model_count": base_model_count,
-            "base_model_percentage": (base_model_count / len(successful_results) * 100) if successful_results else 0
-        }
+        "prompt": prompt,
+        "max_tokens": capped_output,
+        "target_input_tokens": capped_input_tokens,
+        "target_output_tokens": capped_output,
     }
 
 
@@ -340,107 +493,87 @@ def worker_process(worker_id: int, user_requests: List[Dict], api_base: str, mod
 
 def aggregate_metrics(worker_results: List[Dict]) -> Dict:
     """Aggregate metrics from multiple workers (enhanced with TTFT)."""
-    
-    # Combine all token lists
-    all_input_tokens = []
-    all_output_tokens = []
-    
-    # Combine TTFT metrics
-    all_ttft = []
-    all_input_throughput = []
-    all_output_throughput = []
-    all_tpot = []
-    all_decode_time = []
-    
-    # Track timing info for overall batch timing
-    all_fastest = []
-    all_slowest = []
-    
-    # Track failure counts
+    all_input_tokens: List[int] = []
+    all_output_tokens: List[int] = []
+    all_ttft: List[float] = []
+    all_input_throughput: List[float] = []
+    all_output_throughput: List[float] = []
+    all_tpot: List[float] = []
+    all_decode_time: List[float] = []
+    all_fastest: List[float] = []
+    all_slowest: List[float] = []
+
     total_requests = 0
     total_successful = 0
     total_failed = 0
-    
-    # Track batch-level metrics
-    all_combined_throughput = []
-    all_batch_duration = []
-    all_total_output_tokens = []
-    all_total_requests = []
-    
-    latest_end = 0
-    
+    ttft_missing_count = 0
+    latest_end = 0.0
+
     for metrics in worker_results:
-        all_input_tokens.extend(metrics["tokens"]["input_per_request"])
-        all_output_tokens.extend(metrics["tokens"]["output_per_request"])
-        
-        # Aggregate prefill metrics
+        all_input_tokens.extend(metrics.get("tokens", {}).get("input_per_request", []))
+        all_output_tokens.extend(metrics.get("tokens", {}).get("output_per_request", []))
         all_ttft.extend(metrics.get("prefill_metrics", {}).get("ttft_per_request", []))
         all_input_throughput.extend(metrics.get("prefill_metrics", {}).get("input_throughput_per_request", []))
-        
-        # Aggregate decode metrics
         all_output_throughput.extend(metrics.get("decode_metrics", {}).get("output_throughput_per_request", []))
         all_tpot.extend(metrics.get("decode_metrics", {}).get("tpot_per_request", []))
         all_decode_time.extend(metrics.get("decode_metrics", {}).get("decode_time_per_request", []))
-        
-        # Aggregate batch-level metrics
-        batch_metrics = metrics.get("batch_metrics", {})
-        all_combined_throughput.append(batch_metrics.get("combined_throughput", 0))
-        all_batch_duration.append(batch_metrics.get("batch_duration", 0))
-        all_total_output_tokens.append(batch_metrics.get("total_output_tokens", 0))
-        all_total_requests.append(batch_metrics.get("total_requests", 0))
-        
-        # Aggregate failure counts
+        ttft_missing_count += int(metrics.get("prefill_metrics", {}).get("ttft_missing_count", 0))
+
         failures = metrics.get("failures", {})
-        total_requests += failures.get("total_requests", 0)
-        total_successful += failures.get("successful", 0)
-        total_failed += failures.get("failed", 0)
-        
-        all_fastest.append(metrics["timings"]["fastest_seconds"])
-        all_slowest.append(metrics["timings"]["slowest_seconds"])
-        
-        # For overall batch timing, we need to consider that workers ran in parallel
-        # So we take the maximum batch time across all workers
-        latest_end = max(latest_end, metrics["timings"]["batch_total_seconds"])
-    
-    # Aggregate metrics
-    aggregated = {
+        total_requests += int(failures.get("total_requests", 0))
+        total_successful += int(failures.get("successful", 0))
+        total_failed += int(failures.get("failed", 0))
+
+        timings = metrics.get("timings", {})
+        all_fastest.append(float(timings.get("fastest_seconds", 0)))
+        all_slowest.append(float(timings.get("slowest_seconds", 0)))
+        latest_end = max(latest_end, float(timings.get("batch_total_seconds", 0)))
+
+    total_input_tokens = sum(all_input_tokens)
+    total_output_tokens = sum(all_output_tokens)
+    total_tokens = total_input_tokens + total_output_tokens
+    total_token_throughput = total_tokens / latest_end if latest_end > 0 else 0
+    output_token_throughput = total_output_tokens / latest_end if latest_end > 0 else 0
+    decode_throughput_sum = sum(all_output_throughput)
+
+    return {
         "tokens": {
             "input_per_request": all_input_tokens,
             "output_per_request": all_output_tokens
         },
         "timings": {
-            "batch_total_seconds": latest_end,  # Max time across all workers
+            "batch_total_seconds": latest_end,
             "fastest_seconds": min(all_fastest) if all_fastest else 0,
             "slowest_seconds": max(all_slowest) if all_slowest else 0,
             "spread_seconds": max(all_slowest) - min(all_fastest) if all_slowest and all_fastest else 0
         },
-        # Aggregated prefill metrics
         "prefill_metrics": {
             "ttft_per_request": all_ttft,
-            "input_throughput_per_request": all_input_throughput
+            "input_throughput_per_request": all_input_throughput,
+            "ttft_missing_count": ttft_missing_count,
         },
-        # Aggregated decode metrics  
         "decode_metrics": {
             "output_throughput_per_request": all_output_throughput,
             "tpot_per_request": all_tpot,
             "decode_time_per_request": all_decode_time
         },
-        # Aggregated batch-level metrics
         "batch_metrics": {
-            "combined_throughput": sum(all_combined_throughput),  # Sum across all workers for true batch throughput
-            "batch_duration": max(all_batch_duration) if all_batch_duration else 0,  # Max duration (parallel execution)
-            "total_output_tokens": sum(all_total_output_tokens),
-            "total_requests": sum(all_total_requests)
+            "total_input_tokens": total_input_tokens,
+            "total_output_tokens": total_output_tokens,
+            "total_tokens": total_tokens,
+            "batch_duration": latest_end,
+            "total_token_throughput": total_token_throughput,
+            "output_token_throughput": output_token_throughput,
+            "combined_decode_throughput_sum": decode_throughput_sum,
+            "combined_throughput": total_token_throughput,
+            "total_requests": total_successful
         },
-        # Aggregated failure tracking
         "failures": {
             "total_requests": total_requests,
             "successful": total_successful,
             "failed": total_failed
         }
     }
-    
-    return aggregated
 
 
 def run_multiprocess_benchmark(user_requests: List[Dict], api_base: str, model: str,
@@ -548,8 +681,15 @@ def calculate_stats(runs_data: List[Dict]) -> Dict:
     all_decode_time = []
     
     # Batch-level metrics (one value per run)
-    all_combined_throughput = []
+    all_total_token_throughput = []
+    all_output_token_throughput = []
+    all_combined_decode_throughput_sum = []
     all_batch_duration = []
+    all_total_tokens_per_run = []
+    all_total_output_tokens_per_run = []
+    all_total_input_tokens_per_run = []
+    all_success_requests_per_run = []
+    all_ttft_missing_count = []
     
     # For single-value metrics, collect one value per run
     batch_total_seconds = []
@@ -579,20 +719,15 @@ def calculate_stats(runs_data: List[Dict]) -> Dict:
         
         # Batch-level metrics (one value per run)
         batch_metrics = run_data.get("batch_metrics", {})
-        # Handle both single values and arrays from aggregation
-        combined_tp = batch_metrics.get("combined_throughput", batch_metrics.get("combined_throughput_per_batch", [0]))
-        batch_dur = batch_metrics.get("batch_duration", batch_metrics.get("batch_duration_per_batch", [0]))
-        
-        # If it's an array (from aggregation), take the values; if single value, use it
-        if isinstance(combined_tp, list):
-            all_combined_throughput.extend(combined_tp)
-        else:
-            all_combined_throughput.append(combined_tp)
-            
-        if isinstance(batch_dur, list):
-            all_batch_duration.extend(batch_dur)  
-        else:
-            all_batch_duration.append(batch_dur)
+        all_total_token_throughput.append(batch_metrics.get("total_token_throughput", batch_metrics.get("combined_throughput", 0)))
+        all_output_token_throughput.append(batch_metrics.get("output_token_throughput", 0))
+        all_combined_decode_throughput_sum.append(batch_metrics.get("combined_decode_throughput_sum", 0))
+        all_batch_duration.append(batch_metrics.get("batch_duration", 0))
+        all_total_tokens_per_run.append(batch_metrics.get("total_tokens", 0))
+        all_total_output_tokens_per_run.append(batch_metrics.get("total_output_tokens", 0))
+        all_total_input_tokens_per_run.append(batch_metrics.get("total_input_tokens", 0))
+        all_success_requests_per_run.append(batch_metrics.get("total_requests", 0))
+        all_ttft_missing_count.append(prefill_metrics.get("ttft_missing_count", 0))
         
         batch_total_seconds.append(run_data["timings"]["batch_total_seconds"])
         fastest_seconds.append(run_data["timings"]["fastest_seconds"])
@@ -644,6 +779,10 @@ def calculate_stats(runs_data: List[Dict]) -> Dict:
             "input_throughput": {
                 "mean": safe_mean(all_input_throughput),
                 "std": safe_std(all_input_throughput)
+            },
+            "ttft_missing_count_per_run": {
+                "mean": safe_mean(all_ttft_missing_count),
+                "std": safe_std(all_ttft_missing_count)
             }
         },
         # Decode phase statistics
@@ -664,12 +803,40 @@ def calculate_stats(runs_data: List[Dict]) -> Dict:
         # Batch-level combined statistics
         "batch_metrics": {
             "combined_throughput": {
-                "mean": safe_mean(all_combined_throughput),
-                "std": safe_std(all_combined_throughput)
+                "mean": safe_mean(all_total_token_throughput),
+                "std": safe_std(all_total_token_throughput)
+            },
+            "total_token_throughput": {
+                "mean": safe_mean(all_total_token_throughput),
+                "std": safe_std(all_total_token_throughput)
+            },
+            "output_token_throughput": {
+                "mean": safe_mean(all_output_token_throughput),
+                "std": safe_std(all_output_token_throughput)
+            },
+            "combined_decode_throughput_sum": {
+                "mean": safe_mean(all_combined_decode_throughput_sum),
+                "std": safe_std(all_combined_decode_throughput_sum)
             },
             "batch_duration": {
                 "mean": safe_mean(all_batch_duration),
                 "std": safe_std(all_batch_duration)
+            },
+            "total_tokens": {
+                "mean": safe_mean(all_total_tokens_per_run),
+                "std": safe_std(all_total_tokens_per_run)
+            },
+            "total_input_tokens": {
+                "mean": safe_mean(all_total_input_tokens_per_run),
+                "std": safe_std(all_total_input_tokens_per_run)
+            },
+            "total_output_tokens": {
+                "mean": safe_mean(all_total_output_tokens_per_run),
+                "std": safe_std(all_total_output_tokens_per_run)
+            },
+            "successful_requests": {
+                "mean": safe_mean(all_success_requests_per_run),
+                "std": safe_std(all_success_requests_per_run)
             }
         },
         # Failure/Success metrics
@@ -678,13 +845,17 @@ def calculate_stats(runs_data: List[Dict]) -> Dict:
             "successful_requests": total_successful, 
             "failed_requests": total_failed,
             "success_rate": (total_successful / total_requests * 100) if total_requests > 0 else 0,
-            "failure_rate": (total_failed / total_requests * 100) if total_requests > 0 else 0
+            "failure_rate": (total_failed / total_requests * 100) if total_requests > 0 else 0,
+            "ttft_missing_count": int(sum(all_ttft_missing_count)),
+            "ttft_coverage_rate": ((total_successful - sum(all_ttft_missing_count)) / total_successful * 100)
+                                 if total_successful > 0 else 0
         }
     }
 
 
 def warmup_server(api_base: str, model: str, temperature: float, timeout: int,
-                  text_sampler, batch_sampler, num_warmup_runs: int = 3):
+                  text_sampler, batch_sampler, num_warmup_runs: int = 3,
+                  max_input_tokens_cap: int = 0, max_output_tokens_cap: int = 0):
     """Perform warmup runs to prepare the server before benchmarking."""
     print(f"Performing {num_warmup_runs} warmup runs...", end="", flush=True)
     
@@ -701,12 +872,13 @@ def warmup_server(api_base: str, model: str, temperature: float, timeout: int,
             max_tokens = warmup_request.target_output_tokens
             max_tokens = max(1, min(4096, int(max_tokens)))  # Same bounds as main benchmark
             
-            warmup_data = {
-                "prompt": warmup_request.prompt,
-                "max_tokens": max_tokens,
-                "target_input_tokens": warmup_request.target_input_tokens,
-                "target_output_tokens": warmup_request.target_output_tokens
-            }
+            warmup_data = build_request_dict(
+                warmup_request,
+                text_sampler.tokenizer,
+                max_input_tokens_cap=max_input_tokens_cap,
+                max_output_tokens_cap=max_output_tokens_cap,
+            )
+            warmup_data["max_tokens"] = min(warmup_data["max_tokens"], max_tokens)
             
             # Use tokenizer from text_sampler (already loaded)
             tokenizer = text_sampler.tokenizer
@@ -743,6 +915,16 @@ def main():
     parser.add_argument("--batch-sizes", default="1,2,4,8", help="Comma-separated batch sizes")
     parser.add_argument("--num-runs", type=int, default=3, help="Number of runs per batch size")
     parser.add_argument("--warmup-runs", type=int, default=3, help="Number of warmup runs before each batch size")
+    parser.add_argument("--execution-mode", choices=["burst", "refill"], default="burst",
+                        help="burst: fixed one-shot batch, refill: maintain max concurrency with prompt refill.")
+    parser.add_argument("--num-prompts", type=int, default=0,
+                        help="Total prompts per run in refill mode (must be > max_concurrency). 0 => auto.")
+    parser.add_argument("--max-concurrency", type=int, default=0,
+                        help="Override max in-flight requests. 0 => use current batch_size.")
+    parser.add_argument("--max-input-tokens-cap", type=int, default=0,
+                        help="Hard cap for input tokens per request after sampling. 0 => no cap.")
+    parser.add_argument("--max-output-tokens-cap", type=int, default=0,
+                        help="Hard cap for output max_tokens per request. 0 => no cap.")
     parser.add_argument("--temperature", type=float, default=0.7, help="Temperature parameter")
     parser.add_argument("--description", default="Enhanced benchmark", help="Description of the benchmark")
     
@@ -801,6 +983,11 @@ def main():
             "batch_sizes": batch_sizes,
             "num_runs": args.num_runs,
             "warmup_runs": args.warmup_runs,
+            "execution_mode": args.execution_mode,
+            "num_prompts": args.num_prompts,
+            "max_concurrency": args.max_concurrency,
+            "max_input_tokens_cap": args.max_input_tokens_cap,
+            "max_output_tokens_cap": args.max_output_tokens_cap,
             "temperature": args.temperature,
             "description": args.description,
             "seed": args.seed,
@@ -815,12 +1002,26 @@ def main():
     
     # Run benchmark for each batch size
     for batch_size in batch_sizes:
-        print(f"\n🔄 Testing batch size: {batch_size}")
+        effective_max_concurrency = args.max_concurrency if args.max_concurrency > 0 else batch_size
+        prompts_per_run = batch_size
+        if args.execution_mode == "refill":
+            prompts_per_run = args.num_prompts if args.num_prompts > 0 else max(32, effective_max_concurrency * 4)
+            if prompts_per_run <= effective_max_concurrency:
+                raise ValueError(
+                    f"num_prompts ({prompts_per_run}) must be > max_concurrency ({effective_max_concurrency}) in refill mode"
+                )
+
+        print(
+            f"\n🔄 Testing batch size: {batch_size} | mode={args.execution_mode} "
+            f"| max_concurrency={effective_max_concurrency} | prompts_per_run={prompts_per_run}"
+        )
         
         warmup_seed = derive_seed(args.seed, batch_size, -1)
         with use_seed(warmup_seed):
             warmup_server(args.api_base, args.model, args.temperature, args.timeout,
-                         text_sampler, batch_sampler, args.warmup_runs)
+                         text_sampler, batch_sampler, args.warmup_runs,
+                         max_input_tokens_cap=args.max_input_tokens_cap,
+                         max_output_tokens_cap=args.max_output_tokens_cap)
         
         runs_data = []
         for run_idx in range(args.num_runs):
@@ -829,27 +1030,21 @@ def main():
             # Generate batch of requests using scenario (on-demand)
             run_seed = derive_seed(args.seed, batch_size, run_idx)
             with use_seed(run_seed):
-                sampled_requests = batch_sampler.sample_batch(scenario, batch_size)
+                sampled_requests = batch_sampler.sample_batch(scenario, prompts_per_run)
 
             # Assign LoRAs if config is provided
             lora_assignments = None
             if lora_config:
-                lora_assignments = lora_config.assign_lora(batch_size)
+                lora_assignments = lora_config.assign_lora(prompts_per_run)
 
             user_requests = []
             for idx, request in enumerate(sampled_requests):
-                # Use scenario's sampled output tokens
-                max_tokens = request.target_output_tokens
-
-                # Ensure max_tokens is reasonable (at least 1, at most 4096)
-                max_tokens = max(1, min(4096, int(max_tokens)))
-
-                request_dict = {
-                    "prompt": request.prompt,
-                    "max_tokens": max_tokens,
-                    "target_input_tokens": request.target_input_tokens,
-                    "target_output_tokens": request.target_output_tokens
-                }
+                request_dict = build_request_dict(
+                    request,
+                    text_sampler.tokenizer,
+                    max_input_tokens_cap=args.max_input_tokens_cap,
+                    max_output_tokens_cap=args.max_output_tokens_cap,
+                )
 
                 # Add LoRA assignment if available
                 if lora_assignments:
@@ -857,11 +1052,29 @@ def main():
 
                 user_requests.append(request_dict)
             
-            # Run the batch (using multiprocessing like original)
-            run_data = run_multiprocess_benchmark(
-                user_requests, args.api_base, args.model, args.temperature, args.timeout,
-                multiprocessing.cpu_count()
-            )
+            if args.execution_mode == "refill":
+                run_data = asyncio.run(
+                    run_refill_async(
+                        user_requests,
+                        args.api_base,
+                        args.model,
+                        args.temperature,
+                        args.timeout,
+                        effective_max_concurrency,
+                        tokenizer=text_sampler.tokenizer,
+                    )
+                )
+                failures = run_data.get("failures", {})
+                total_req = failures.get("total_requests", 0)
+                successful = failures.get("successful", 0)
+                failed = failures.get("failed", 0)
+                print(f"    📊 Request Results: {successful}/{total_req} successful, {failed} failed")
+            else:
+                # Run the batch (legacy one-shot mode with multiprocessing)
+                run_data = run_multiprocess_benchmark(
+                    user_requests, args.api_base, args.model, args.temperature, args.timeout,
+                    multiprocessing.cpu_count()
+                )
             
             
             runs_data.append(run_data)
@@ -892,21 +1105,21 @@ def main():
                 avg_output_throughput = statistics.mean(output_throughput_values) if output_throughput_values else 0
                 avg_decode_time = statistics.mean(decode_time_values) if decode_time_values else 0
                 
-                # Extract batch-level combined throughput
+                # Extract batch-level throughput metrics
                 batch_metrics = run_data.get("batch_metrics", {})
-                # Handle both single values and arrays from aggregation
-                combined_tp = batch_metrics.get("combined_throughput", batch_metrics.get("combined_throughput_per_batch", [0]))
-                if isinstance(combined_tp, list):
-                    combined_throughput = sum(combined_tp) if combined_tp else 0
-                else:
-                    combined_throughput = combined_tp
+                total_token_throughput = batch_metrics.get(
+                    "total_token_throughput",
+                    batch_metrics.get("combined_throughput", 0),
+                )
+                decode_sum_throughput = batch_metrics.get("combined_decode_throughput_sum", 0)
                 
                 success_rate = (successful / total_req * 100) if total_req > 0 else 0
                 print(f"    ✅ Batch: {batch_time:.2f}s | Success: {successful}/{total_req} ({success_rate:.1f}%)")
                 if failed > 0:
                     print(f"       ❌ {failed} requests failed")
                 print(f"       Tokens - Input: {total_input_tokens:,} | Output: {total_output_tokens:,}")
-                print(f"       Combined Throughput: {combined_throughput:.1f} tok/s (sum of all decode speeds)")
+                print(f"       Total Throughput: {total_token_throughput:.1f} tok/s (input+output over batch window)")
+                print(f"       Decode Sum Throughput (legacy): {decode_sum_throughput:.1f} tok/s")
                 
                 if avg_ttft > 0:
                     print(f"       Per-Request Avg - TTFT: {avg_ttft:.3f}s | Prefill: {avg_input_throughput:.1f} tok/s | Decode: {avg_output_throughput:.1f} tok/s | Decode Time: {avg_decode_time:.3f}s")


### PR DESCRIPTION
This PR adds the benchmark behavior used in our reproduction runs:\n\n- refill-loop execution mode to maintain target concurrency\n- robust first-token detection for TTFT\n- improved throughput/latency accounting and summaries\n- explicit handling for missing/failed points\n\nUsed by downstream vLLM/SGLang reproducibility docs and Slurm scripts.