### PR TITLE
Align measurement/HTTP path with aiperf

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ tokenomics plot-completion output.png results_dir1/ results_dir2/
 
 | | Left | Right |
 |---|------|-------|
-| **Row 1** | TTFT | Decode throughput per request |
+| **Row 1** | TTFT (with TTFO overlaid when it diverges, i.e. reasoning models) | Decode throughput per request |
 | **Row 2** | End-to-end output throughput | Latency breakdown (prefill vs decode) |
 | **Row 3** | Steady-state output throughput | Time-series token buckets |
 

--- a/tokenomics/completion_benchmark.py
+++ b/tokenomics/completion_benchmark.py
@@ -5,13 +5,19 @@ OAI server benchmark with scenario-based sampling.
 import argparse
 import asyncio
 import aiohttp
+import socket
 import time
 import json
 import os
 import random
 import numpy as np
 from datetime import datetime
-from typing import List, Dict, Any, Optional
+from typing import Callable, List, Dict, Any, Optional
+
+# Latency is measured with the monotonic perf_counter_ns clock and kept as
+# integer nanoseconds internally; values are converted to seconds only at the
+# return boundary. NEVER use time.time() for latency (wall clock can jump).
+NS_PER_SECOND = 1_000_000_000
 
 os.environ["HF_DATASETS_DISABLE_PROGRESS_BARS"] = "1"
 os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
@@ -91,11 +97,12 @@ async def _iter_sse_events(response):
     Robust to chunk boundaries: a single SSE event may span multiple TCP
     chunks, or multiple events may arrive in one chunk.
 
-    ``arrival_perf`` is ``time.perf_counter()`` stamped the instant the chunk
-    that completes the event lands off the socket, BEFORE any JSON parsing, so
-    first-token and per-token timing exclude client-side parse/event-loop
-    latency. ``event_name`` carries the SSE ``event:`` field (``None`` when
-    absent) so callers can detect mid-stream ``event: error`` frames.
+    ``arrival_perf`` is ``time.perf_counter_ns()`` (integer nanoseconds)
+    stamped the instant the chunk that completes the event lands off the
+    socket, BEFORE any JSON parsing, so first-token and per-token timing
+    exclude client-side parse/event-loop latency. ``event_name`` carries the
+    SSE ``event:`` field (``None`` when absent) so callers can detect
+    mid-stream ``event: error`` frames.
     """
     buffer = ""
     event_name = None
@@ -107,7 +114,7 @@ async def _iter_sse_events(response):
             continue
         # Stamp arrival before decoding/parsing so the timestamp reflects when
         # the bytes hit the socket, not when we finished processing them.
-        chunk_perf = time.perf_counter()
+        chunk_perf = time.perf_counter_ns()
         buffer += chunk.decode("utf-8", errors="replace")
         while "\n" in buffer:
             raw_line, buffer = buffer.split("\n", 1)
@@ -131,7 +138,7 @@ async def _iter_sse_events(response):
 
     # Flush remaining data
     if event_data_lines:
-        yield (chunk_perf if chunk_perf is not None else time.perf_counter()), event_name, "\n".join(event_data_lines)
+        yield (chunk_perf if chunk_perf is not None else time.perf_counter_ns()), event_name, "\n".join(event_data_lines)
 
 
 def _extract_text_from_delta(delta: Dict[str, Any]) -> str:
@@ -156,15 +163,68 @@ def _extract_text_from_delta(delta: Dict[str, Any]) -> str:
     return "".join(pieces)
 
 
+def _extract_output_text_from_delta(delta: Dict[str, Any]) -> str:
+    """Extract only the non-reasoning output text from a delta.
+
+    Same shape as ``_extract_text_from_delta`` but excludes the reasoning
+    fields, so callers can detect the first actual output token (TTFO) for
+    reasoning models, distinct from the first token overall (TTFT).
+    """
+    pieces = []
+    for key in ("content", "text", "output_text"):
+        value = delta.get(key)
+        if isinstance(value, str):
+            pieces.append(value)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, str):
+                    pieces.append(item)
+                elif isinstance(item, dict):
+                    for sub_key in ("content", "text", "output_text"):
+                        sub_val = item.get(sub_key)
+                        if isinstance(sub_val, str):
+                            pieces.append(sub_val)
+    return "".join(pieces)
+
+
+def _create_connector() -> aiohttp.TCPConnector:
+    """Build a TCPConnector with TCP_NODELAY for low-latency SSE delivery.
+
+    Disabling Nagle's algorithm stops small SSE frames from being coalesced,
+    which would smear per-token arrival timing. Uses aiohttp's socket_factory
+    (>=3.9) and falls back gracefully on older aiohttp.
+    """
+    def socket_factory(addr_info):
+        family, sock_type, proto = addr_info[0], addr_info[1], addr_info[2]
+        sock = socket.socket(family=family, type=sock_type, proto=proto)
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        return sock
+
+    try:
+        return aiohttp.TCPConnector(limit=0, socket_factory=socket_factory)
+    except TypeError:
+        # Older aiohttp without socket_factory support.
+        return aiohttp.TCPConnector(limit=0)
+
+
 async def single_request(session: aiohttp.ClientSession, api_base: str, model: str,
                         request_data: Dict[str, Any], temperature: float,
                         timeout: int, api_key: str = "dummy-key",
-                        n: int = 1, stream: bool = True) -> Dict:
-    """Make a single API request, returning per-request metrics."""
-    request_start = time.perf_counter()
+                        n: int = 1, stream: bool = True,
+                        token_counter: Optional[Callable[[str], int]] = None) -> Dict:
+    """Make a single API request, returning per-request metrics.
+
+    All internal timestamps are integer nanoseconds (perf_counter_ns); the
+    returned timing fields are seconds. ``token_counter``, when provided, is
+    used to count output tokens client-side when the server omits usage info,
+    instead of the crude one-chunk-per-token estimate.
+    """
+    request_start = time.perf_counter_ns()
     time_at_first_token = None
+    time_at_first_output_token = None
     last_content_perf = None
     chunk_timestamps = []
+    output_text_parts = []
 
     lora_name = request_data.get("lora_name")
     model_str = f"{model}:{lora_name}" if lora_name else model
@@ -219,30 +279,43 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
                     if chunk_data.get("usage"):
                         api_usage = chunk_data["usage"]
 
-                    choices = chunk_data.get("choices", [])
-                    has_content = any(
-                        _extract_text_from_delta(choice.get("delta", {}))
-                        for choice in choices
-                    )
-                    if has_content:
+                    chunk_full_text = ""
+                    chunk_output_text = ""
+                    for choice in chunk_data.get("choices", []):
+                        delta = choice.get("delta", {})
+                        chunk_full_text += _extract_text_from_delta(delta)
+                        chunk_output_text += _extract_output_text_from_delta(delta)
+
+                    if chunk_full_text:
                         # arrival_perf was stamped at socket-arrival, before JSON
                         # parsing, so TTFT and per-token timing exclude parse cost.
                         if time_at_first_token is None:
                             time_at_first_token = arrival_perf
                         chunk_timestamps.append(arrival_perf)
                         last_content_perf = arrival_perf
+                        output_text_parts.append(chunk_full_text)
+                    # First non-reasoning output token (TTFO), distinct from TTFT.
+                    if chunk_output_text and time_at_first_output_token is None:
+                        time_at_first_output_token = arrival_perf
             else:
                 resp_data = json.loads(await response.read())
                 api_usage = resp_data.get("usage")
+                # Accumulate output text for the client-side token fallback.
+                for choice in resp_data.get("choices", []):
+                    output_text_parts.append(
+                        _extract_text_from_delta(choice.get("message", {}))
+                    )
 
-            request_end = time.perf_counter()
+            request_end = time.perf_counter_ns()
             # End the latency window at the last content token, not the trailing
             # usage/[DONE] chunk (which lands ~1 RTT later). Matches aiperf, where
             # request latency = timestamp of the last content response.
             content_end_perf = last_content_perf if last_content_perf is not None else request_end
 
-            ttft = time_at_first_token - request_start if time_at_first_token else 0
-            e2e_latency = content_end_perf - request_start
+            # Convert ns deltas to seconds at the boundary.
+            ttft = (time_at_first_token - request_start) / NS_PER_SECOND if time_at_first_token else 0
+            ttfo = (time_at_first_output_token - request_start) / NS_PER_SECOND if time_at_first_output_token else 0
+            e2e_latency = (content_end_perf - request_start) / NS_PER_SECOND
             output_latency = e2e_latency - ttft if ttft > 0 else e2e_latency
 
             if api_usage:
@@ -252,6 +325,12 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
                 # reasoning_tokens on top of completion_tokens, double-counting
                 # reasoning for models that fold it in (vLLM, OpenAI).
                 output_tokens = api_usage.get("completion_tokens", 0)
+            elif token_counter is not None:
+                # No server usage: tokenize the generated text client-side
+                # (OSL = output + reasoning tokens), matching aiperf's client-side
+                # fallback, instead of guessing 1 chunk ≈ 1 token.
+                input_tokens = request_data.get("target_input_tokens", 0)
+                output_tokens = token_counter("".join(output_text_parts))
             else:
                 input_tokens = request_data.get("target_input_tokens", 0)
                 output_tokens = len(chunk_timestamps)  # 1 chunk ≈ 1 token
@@ -266,14 +345,15 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
             return {
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
-                "start_time": request_start,
-                "end_time": content_end_perf,
+                "start_time": request_start / NS_PER_SECOND,
+                "end_time": content_end_perf / NS_PER_SECOND,
                 "ttft": ttft,
+                "ttfo": ttfo,
                 "output_latency": output_latency,
                 "input_throughput": input_throughput,
                 "output_throughput": output_throughput,
                 "tpot": tpot,
-                "chunk_timestamps": chunk_timestamps,
+                "chunk_timestamps": [t / NS_PER_SECOND for t in chunk_timestamps],
                 "status": response.status,
                 "success": True
             }
@@ -286,7 +366,8 @@ async def run_batch_async(user_requests: List[Dict], api_base: str, model: str,
                          temperature: float, timeout: int,
                          max_concurrency: Optional[int] = None,
                          api_key: str = "dummy-key",
-                         n: int = 1, stream: bool = True) -> Dict:
+                         n: int = 1, stream: bool = True,
+                         token_counter: Optional[Callable[[str], int]] = None) -> Dict:
     """Run batch of requests asynchronously.
 
     Args:
@@ -294,23 +375,29 @@ async def run_batch_async(user_requests: List[Dict], api_base: str, model: str,
             requests using a semaphore (sustained-load mode). When None, all
             requests are fired at once (burst mode).
         n: Number of completions per request.
+        token_counter: Optional client-side output-token counter used when the
+            server omits usage info.
     """
     semaphore = asyncio.Semaphore(max_concurrency) if max_concurrency else None
     start_time = time.perf_counter()
 
     async def send_request(session, req):
         if semaphore is None:
-            return await single_request(session, api_base, model, req, temperature, timeout, api_key, n=n, stream=stream)
+            return await single_request(session, api_base, model, req, temperature, timeout, api_key, n=n, stream=stream, token_counter=token_counter)
 
         async with semaphore:
-            return await single_request(session, api_base, model, req, temperature, timeout, api_key, n=n, stream=stream)
+            return await single_request(session, api_base, model, req, temperature, timeout, api_key, n=n, stream=stream, token_counter=token_counter)
 
-    # Match sglang's read_bufsize (10MB) to avoid event loop bottleneck at high concurrency.
-    # Default 64KB buffer can cause excessive read syscalls under pressure.
-    connector = aiohttp.TCPConnector(limit=0)
+    # TCP_NODELAY connector so small SSE frames aren't coalesced (distorting
+    # per-token timing). Match sglang's read_bufsize (10MB) to avoid an event
+    # loop bottleneck at high concurrency, and skip aiohttp's auto headers
+    # (User-Agent / Accept-Encoding) to keep the request minimal and avoid
+    # response gzip that would add decode latency to chunk timing.
+    connector = _create_connector()
     async with aiohttp.ClientSession(
         connector=connector,
         read_bufsize=10 * 1024**2,
+        skip_auto_headers=["User-Agent", "Accept-Encoding"],
     ) as session:
         tasks = [send_request(session, req) for req in user_requests]
         results = await asyncio.gather(*tasks)
@@ -330,6 +417,7 @@ async def run_batch_async(user_requests: List[Dict], api_base: str, model: str,
         "batch_total_seconds": batch_total_seconds,
         "prefill_metrics": {
             "ttft_per_request": [r["ttft"] for r in successful_results if r["ttft"] > 0],
+            "ttfo_per_request": [r["ttfo"] for r in successful_results if r.get("ttfo", 0) > 0],
             "input_throughput_per_request": [r["input_throughput"] for r in successful_results if r["input_throughput"] > 0],
         },
         "decode_metrics": {
@@ -360,10 +448,12 @@ def run_benchmark_batch(user_requests: List[Dict], api_base: str, model: str,
                         temperature: float, timeout: int,
                         max_concurrency: Optional[int] = None,
                         api_key: str = "dummy-key",
-                        n: int = 1, stream: bool = True) -> Dict:
+                        n: int = 1, stream: bool = True,
+                        token_counter: Optional[Callable[[str], int]] = None) -> Dict:
     """Run a batch of requests and return results."""
     result = asyncio.run(run_batch_async(user_requests, api_base, model, temperature, timeout,
-                                         max_concurrency=max_concurrency, api_key=api_key, n=n, stream=stream))
+                                         max_concurrency=max_concurrency, api_key=api_key, n=n, stream=stream,
+                                         token_counter=token_counter))
 
     failures = result["failures"]
     print(f"    📊 {failures['successful']}/{failures['total_requests']} successful"
@@ -480,6 +570,7 @@ def calculate_stats(runs_data: List[Dict], steady_state_threshold: float = 0.8,
     
     # Individual request metrics (flattened across runs)
     all_ttft = []
+    all_ttfo = []
     all_input_throughput = []
     all_output_throughput = []
     all_tpot = []
@@ -504,6 +595,7 @@ def calculate_stats(runs_data: List[Dict], steady_state_threshold: float = 0.8,
         # Prefill metrics
         prefill_metrics = run_data.get("prefill_metrics", {})
         all_ttft.extend(prefill_metrics.get("ttft_per_request", []))
+        all_ttfo.extend(prefill_metrics.get("ttfo_per_request", []))
         all_input_throughput.extend(prefill_metrics.get("input_throughput_per_request", []))
         
         # Decode metrics
@@ -545,6 +637,7 @@ def calculate_stats(runs_data: List[Dict], steady_state_threshold: float = 0.8,
         },
         "prefill_metrics": {
             "ttft": {"mean": _safe_mean(all_ttft), "std": _safe_std(all_ttft)},
+            "ttfo": {"mean": _safe_mean(all_ttfo), "std": _safe_std(all_ttfo)},
             "input_throughput": {"mean": _safe_mean(all_input_throughput), "std": _safe_std(all_input_throughput)},
         },
         "decode_metrics": {
@@ -668,6 +761,15 @@ def main():
 
     text_sampler = TextSampler(tokenizer_name, dataset_loader)
 
+    def count_output_tokens(text: str) -> int:
+        """Client-side output-token count used when the server omits usage."""
+        if not text:
+            return 0
+        try:
+            return len(text_sampler.tokenizer.encode(text).ids)
+        except Exception:
+            return int(len(text.split()) * 1.3)
+
     print(f"📊 Initialized benchmark with scenario: {args.scenario}")
     print(f"📚 Loaded dataset: {len(dataset_loader)} samples")
     print(f"⚙️  Execution mode: {execution_mode}")
@@ -753,7 +855,8 @@ def main():
             run_data = run_benchmark_batch(
                 user_requests, args.api_base, args.model, args.temperature, args.timeout,
                 max_concurrency=max_concurrency, api_key=args.api_key,
-                n=args.num_completions, stream=args.stream
+                n=args.num_completions, stream=args.stream,
+                token_counter=count_output_tokens
             )
 
             runs_data.append(run_data)

--- a/tokenomics/completion_benchmark.py
+++ b/tokenomics/completion_benchmark.py
@@ -11,6 +11,7 @@ import json
 import os
 import random
 import numpy as np
+from collections import Counter
 from datetime import datetime
 from typing import Callable, List, Dict, Any, Optional
 
@@ -187,6 +188,40 @@ def _extract_output_text_from_delta(delta: Dict[str, Any]) -> str:
     return "".join(pieces)
 
 
+def _parse_usage_extras(api_usage: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Extract extended usage fields that OpenAI-compatible servers report
+    (OpenRouter, vLLM, ...): reasoning/cached token counts, totals, and cost.
+
+    Robust to the fields being absent or nested. On OpenRouter, reasoning lives
+    under ``completion_tokens_details`` and cached tokens under
+    ``prompt_tokens_details``; other servers report them top-level, so both
+    locations are checked. Only present fields are returned.
+    """
+    if not api_usage:
+        return {}
+    ctd = api_usage.get("completion_tokens_details") or {}
+    ptd = api_usage.get("prompt_tokens_details") or {}
+    extras: Dict[str, Any] = {}
+
+    reasoning = ctd.get("reasoning_tokens")
+    if reasoning is None:
+        reasoning = api_usage.get("reasoning_tokens")
+    if reasoning is not None:
+        extras["reasoning_tokens"] = reasoning
+
+    cached = ptd.get("cached_tokens")
+    if cached is None:
+        cached = api_usage.get("cached_tokens")
+    if cached is not None:
+        extras["cached_tokens"] = cached
+
+    if api_usage.get("total_tokens") is not None:
+        extras["total_tokens"] = api_usage["total_tokens"]
+    if api_usage.get("cost") is not None:
+        extras["cost"] = api_usage["cost"]
+    return extras
+
+
 def _create_connector() -> aiohttp.TCPConnector:
     """Build a TCPConnector with TCP_NODELAY for low-latency SSE delivery.
 
@@ -225,6 +260,9 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
     last_content_perf = None
     chunk_timestamps = []
     output_text_parts = []
+    provider = None
+    finish_reason = None
+    native_finish_reason = None
 
     lora_name = request_data.get("lora_name")
     model_str = f"{model}:{lora_name}" if lora_name else model
@@ -278,6 +316,8 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
                     # Only latch non-empty usage; an empty `{}` is not usage info.
                     if chunk_data.get("usage"):
                         api_usage = chunk_data["usage"]
+                    if chunk_data.get("provider"):
+                        provider = chunk_data["provider"]
 
                     chunk_full_text = ""
                     chunk_output_text = ""
@@ -285,6 +325,10 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
                         delta = choice.get("delta", {})
                         chunk_full_text += _extract_text_from_delta(delta)
                         chunk_output_text += _extract_output_text_from_delta(delta)
+                        if choice.get("finish_reason"):
+                            finish_reason = choice["finish_reason"]
+                        if choice.get("native_finish_reason"):
+                            native_finish_reason = choice["native_finish_reason"]
 
                     if chunk_full_text:
                         # arrival_perf was stamped at socket-arrival, before JSON
@@ -300,11 +344,16 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
             else:
                 resp_data = json.loads(await response.read())
                 api_usage = resp_data.get("usage")
+                provider = resp_data.get("provider")
                 # Accumulate output text for the client-side token fallback.
                 for choice in resp_data.get("choices", []):
                     output_text_parts.append(
                         _extract_text_from_delta(choice.get("message", {}))
                     )
+                    if choice.get("finish_reason"):
+                        finish_reason = choice["finish_reason"]
+                    if choice.get("native_finish_reason"):
+                        native_finish_reason = choice["native_finish_reason"]
 
             request_end = time.perf_counter_ns()
             # End the latency window at the last content token, not the trailing
@@ -342,6 +391,16 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
             output_throughput = (tokens_per_seq - 1) / output_latency if output_latency > 0 and tokens_per_seq > 1 else 0
             tpot = output_latency / (tokens_per_seq - 1) if tokens_per_seq > 1 and output_latency > 0 else 0
 
+            # Extended server-reported fields (reasoning/cached tokens, cost,
+            # provider, finish reason). Useful but absent on many servers.
+            usage_extras = _parse_usage_extras(api_usage)
+            if provider is not None:
+                usage_extras["provider"] = provider
+            if finish_reason is not None:
+                usage_extras["finish_reason"] = finish_reason
+            if native_finish_reason is not None:
+                usage_extras["native_finish_reason"] = native_finish_reason
+
             return {
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
@@ -355,6 +414,7 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
                 "tpot": tpot,
                 "chunk_timestamps": [t / NS_PER_SECOND for t in chunk_timestamps],
                 "status": response.status,
+                "usage_extras": usage_extras,
                 "success": True
             }
 
@@ -409,10 +469,26 @@ async def run_batch_async(user_requests: List[Dict], api_base: str, model: str,
     success_count = len(successful_results)
     failure_count = total_requests - success_count
 
+    # Aggregate extended usage fields (present only on servers that report them).
+    def _extras_list(key):
+        return [r["usage_extras"][key] for r in successful_results
+                if r.get("usage_extras", {}).get(key) is not None]
+
     return {
         "tokens": {
             "input_per_request": [r["input_tokens"] for r in successful_results],
             "output_per_request": [r["output_tokens"] for r in successful_results],
+        },
+        "usage_extras": {
+            "reasoning_tokens_per_request": _extras_list("reasoning_tokens"),
+            "cached_tokens_per_request": _extras_list("cached_tokens"),
+            "cost_per_request": _extras_list("cost"),
+            "finish_reasons": dict(Counter(
+                r["usage_extras"]["finish_reason"] for r in successful_results
+                if r.get("usage_extras", {}).get("finish_reason"))),
+            "providers": dict(Counter(
+                r["usage_extras"]["provider"] for r in successful_results
+                if r.get("usage_extras", {}).get("provider"))),
         },
         "batch_total_seconds": batch_total_seconds,
         "prefill_metrics": {
@@ -588,9 +664,23 @@ def calculate_stats(runs_data: List[Dict], steady_state_threshold: float = 0.8,
     # Per-run phased metrics
     all_run_phased_metrics = []
 
+    # Extended usage fields (present only on servers that report them)
+    all_reasoning_tokens = []
+    all_cached_tokens = []
+    all_cost = []
+    finish_reasons = Counter()
+    providers = Counter()
+
     for run_data in runs_data:
         all_input_tokens.extend(run_data["tokens"]["input_per_request"])
         all_output_tokens.extend(run_data["tokens"]["output_per_request"])
+
+        ue = run_data.get("usage_extras", {})
+        all_reasoning_tokens.extend(ue.get("reasoning_tokens_per_request", []))
+        all_cached_tokens.extend(ue.get("cached_tokens_per_request", []))
+        all_cost.extend(ue.get("cost_per_request", []))
+        finish_reasons.update(ue.get("finish_reasons", {}))
+        providers.update(ue.get("providers", {}))
         
         # Prefill metrics
         prefill_metrics = run_data.get("prefill_metrics", {})
@@ -630,6 +720,33 @@ def calculate_stats(runs_data: List[Dict], steady_state_threshold: float = 0.8,
     # Aggregate phased metrics across runs
     phased_metrics = _aggregate_phased_metrics(all_run_phased_metrics)
 
+    # Summarize extended usage fields; only include sub-keys that have data so
+    # servers that report nothing extra don't litter the output with empties.
+    usage_extras_summary: Dict[str, Any] = {}
+    if all_reasoning_tokens:
+        usage_extras_summary["reasoning_tokens"] = {
+            "mean": _safe_mean(all_reasoning_tokens),
+            "std": _safe_std(all_reasoning_tokens),
+            "total": int(sum(all_reasoning_tokens)),
+        }
+    if all_cached_tokens:
+        total_cached = int(sum(all_cached_tokens))
+        total_input = int(sum(all_input_tokens))
+        usage_extras_summary["cached_tokens"] = {
+            "mean": _safe_mean(all_cached_tokens),
+            "total": total_cached,
+            "cache_hit_rate": (total_cached / total_input) if total_input > 0 else 0,
+        }
+    if all_cost:
+        usage_extras_summary["cost"] = {
+            "mean": _safe_mean(all_cost),
+            "total": float(sum(all_cost)),
+        }
+    if finish_reasons:
+        usage_extras_summary["finish_reasons"] = dict(finish_reasons)
+    if providers:
+        usage_extras_summary["providers"] = dict(providers)
+
     return {
         "tokens": {
             "input_per_request": {"mean": _safe_mean(all_input_tokens), "std": _safe_std(all_input_tokens)},
@@ -654,6 +771,7 @@ def calculate_stats(runs_data: List[Dict], steady_state_threshold: float = 0.8,
             "successful": total_successful,
             "failed": total_failed,
         },
+        "usage_extras": usage_extras_summary,
         "phased_metrics": phased_metrics,
     }
 
@@ -889,6 +1007,21 @@ def main():
             print(f"    Steady-state TPS (median): {steady_state['median']:.1f}{std_str} tok/s")
             print(f"    End-to-end TPS:            {wall_tps:.1f} tok/s")
             print(f"    Peak active requests:      {pm['peak_active_requests']}")
+
+        # Print extended server-reported usage (only what the server returned)
+        ue = batch_stats.get("usage_extras", {})
+        if ue:
+            print(f"  Server Usage Extras:")
+            if "reasoning_tokens" in ue:
+                print(f"    Reasoning tokens (mean):   {ue['reasoning_tokens']['mean']:.1f}")
+            if "cached_tokens" in ue:
+                print(f"    Cache hit rate:            {ue['cached_tokens']['cache_hit_rate'] * 100:.1f}%")
+            if "cost" in ue:
+                print(f"    Cost (total):              ${ue['cost']['total']:.6f}")
+            if ue.get("finish_reasons"):
+                print(f"    Finish reasons:            {ue['finish_reasons']}")
+            if ue.get("providers"):
+                print(f"    Providers:                 {ue['providers']}")
 
         # Write per-sweep-value result file atomically
         result_entry = {

--- a/tokenomics/completion_benchmark.py
+++ b/tokenomics/completion_benchmark.py
@@ -85,18 +85,29 @@ class LoRAConfig:
         return self._apply_base_model_ratio(raw_assignments)
 
 
-async def _iter_sse_data(response):
-    """Yield SSE data payloads, robust to chunk boundaries.
+async def _iter_sse_events(response):
+    """Yield ``(arrival_perf, event_name, data_payload)`` for each SSE event.
 
-    Properly handles cases where a single SSE event spans multiple TCP chunks,
-    or multiple events arrive in a single chunk.
+    Robust to chunk boundaries: a single SSE event may span multiple TCP
+    chunks, or multiple events may arrive in one chunk.
+
+    ``arrival_perf`` is ``time.perf_counter()`` stamped the instant the chunk
+    that completes the event lands off the socket, BEFORE any JSON parsing, so
+    first-token and per-token timing exclude client-side parse/event-loop
+    latency. ``event_name`` carries the SSE ``event:`` field (``None`` when
+    absent) so callers can detect mid-stream ``event: error`` frames.
     """
     buffer = ""
+    event_name = None
     event_data_lines = []
+    chunk_perf = None
 
     async for chunk in response.content.iter_any():
         if not chunk:
             continue
+        # Stamp arrival before decoding/parsing so the timestamp reflects when
+        # the bytes hit the socket, not when we finished processing them.
+        chunk_perf = time.perf_counter()
         buffer += chunk.decode("utf-8", errors="replace")
         while "\n" in buffer:
             raw_line, buffer = buffer.split("\n", 1)
@@ -105,19 +116,22 @@ async def _iter_sse_data(response):
             if line == "":
                 # Empty line = end of SSE event
                 if event_data_lines:
-                    yield "\n".join(event_data_lines)
+                    yield chunk_perf, event_name, "\n".join(event_data_lines)
                     event_data_lines = []
+                    event_name = None
                 continue
 
             if line.startswith(":"):
                 # SSE comment, skip
                 continue
-            if line.startswith("data:"):
+            if line.startswith("event:"):
+                event_name = line[6:].strip()
+            elif line.startswith("data:"):
                 event_data_lines.append(line[5:].lstrip())
 
     # Flush remaining data
     if event_data_lines:
-        yield "\n".join(event_data_lines)
+        yield (chunk_perf if chunk_perf is not None else time.perf_counter()), event_name, "\n".join(event_data_lines)
 
 
 def _extract_text_from_delta(delta: Dict[str, Any]) -> str:
@@ -149,6 +163,7 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
     """Make a single API request, returning per-request metrics."""
     request_start = time.perf_counter()
     time_at_first_token = None
+    last_content_perf = None
     chunk_timestamps = []
 
     lora_name = request_data.get("lora_name")
@@ -174,46 +189,69 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
             timeout=aiohttp.ClientTimeout(total=timeout)
         ) as response:
 
-            if response.status != 200:
-                return {"error": f"API error {response.status}: {await response.text()}", "success": False}
+            # Accept the full 2xx range as success (async job APIs may return
+            # 201/202), matching aiperf's status handling.
+            if not (200 <= response.status < 300):
+                return {"error": f"API error {response.status}: {await response.text()}",
+                        "success": False, "status": response.status}
 
             api_usage = None
 
             if stream:
-                async for data_text in _iter_sse_data(response):
+                async for arrival_perf, event_name, data_text in _iter_sse_events(response):
                     if data_text == "[DONE]":
                         break
+
+                    # A mid-stream `event: error` frame is a failure, not a short
+                    # successful response. Without this, an error frame parses as a
+                    # normal (contentless) chunk and the request is scored as a
+                    # success with a truncated token count.
+                    if event_name == "error":
+                        return {"error": f"SSE error event: {data_text}", "success": False,
+                                "status": response.status}
 
                     try:
                         chunk_data = json.loads(data_text)
                     except json.JSONDecodeError:
                         continue
 
-                    if "usage" in chunk_data:
+                    # Only latch non-empty usage; an empty `{}` is not usage info.
+                    if chunk_data.get("usage"):
                         api_usage = chunk_data["usage"]
 
                     choices = chunk_data.get("choices", [])
-                    for choice in choices:
-                        delta = choice.get("delta", {})
-                        text = _extract_text_from_delta(delta)
-
-                        if text:
-                            if time_at_first_token is None:
-                                time_at_first_token = time.perf_counter()
-                            chunk_timestamps.append(time.perf_counter())
+                    has_content = any(
+                        _extract_text_from_delta(choice.get("delta", {}))
+                        for choice in choices
+                    )
+                    if has_content:
+                        # arrival_perf was stamped at socket-arrival, before JSON
+                        # parsing, so TTFT and per-token timing exclude parse cost.
+                        if time_at_first_token is None:
+                            time_at_first_token = arrival_perf
+                        chunk_timestamps.append(arrival_perf)
+                        last_content_perf = arrival_perf
             else:
                 resp_data = json.loads(await response.read())
                 api_usage = resp_data.get("usage")
 
             request_end = time.perf_counter()
+            # End the latency window at the last content token, not the trailing
+            # usage/[DONE] chunk (which lands ~1 RTT later). Matches aiperf, where
+            # request latency = timestamp of the last content response.
+            content_end_perf = last_content_perf if last_content_perf is not None else request_end
 
             ttft = time_at_first_token - request_start if time_at_first_token else 0
-            e2e_latency = request_end - request_start
+            e2e_latency = content_end_perf - request_start
             output_latency = e2e_latency - ttft if ttft > 0 else e2e_latency
 
             if api_usage:
                 input_tokens = api_usage.get("prompt_tokens", 0)
-                output_tokens = api_usage.get("reasoning_tokens", 0) + api_usage.get("completion_tokens", 0)
+                # aiperf semantic: the server's completion_tokens already includes
+                # reasoning tokens, so OSL == completion_tokens. The old code added
+                # reasoning_tokens on top of completion_tokens, double-counting
+                # reasoning for models that fold it in (vLLM, OpenAI).
+                output_tokens = api_usage.get("completion_tokens", 0)
             else:
                 input_tokens = request_data.get("target_input_tokens", 0)
                 output_tokens = len(chunk_timestamps)  # 1 chunk ≈ 1 token
@@ -229,13 +267,14 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
                 "start_time": request_start,
-                "end_time": request_end,
+                "end_time": content_end_perf,
                 "ttft": ttft,
                 "output_latency": output_latency,
                 "input_throughput": input_throughput,
                 "output_throughput": output_throughput,
                 "tpot": tpot,
                 "chunk_timestamps": chunk_timestamps,
+                "status": response.status,
                 "success": True
             }
 

--- a/tokenomics/plot_completion_benchmark.py
+++ b/tokenomics/plot_completion_benchmark.py
@@ -123,6 +123,7 @@ def extract_metrics(data: Dict) -> Dict:
         'sweep_values': sweep_values,
         'sweep_label': sweep_label,
         'ttft_mean': [], 'ttft_std': [],
+        'ttfo_mean': [], 'ttfo_std': [],
         'output_throughput_mean': [], 'output_throughput_std': [],
         'e2e_tps_mean': [], 'e2e_tps_std': [],
         'steady_state_median_mean': [], 'steady_state_median_std': [],
@@ -139,6 +140,8 @@ def extract_metrics(data: Dict) -> Dict:
 
         metrics['ttft_mean'].append(_get(prefill, "ttft", "mean"))
         metrics['ttft_std'].append(_get(prefill, "ttft", "std"))
+        metrics['ttfo_mean'].append(_get(prefill, "ttfo", "mean"))
+        metrics['ttfo_std'].append(_get(prefill, "ttfo", "std"))
         metrics['output_throughput_mean'].append(_get(decode, "output_throughput", "mean"))
         metrics['output_throughput_std'].append(_get(decode, "output_throughput", "std"))
         metrics['decode_time_mean'].append(_get(decode, "decode_time", "mean"))
@@ -214,6 +217,48 @@ def setup_line_plot(ax, benchmarks, all_ticks: List[int], xlabel: str,
 
     ax.set_title(title, fontsize=14, fontweight='bold', pad=20)
     ax.set_ylabel(ylabel, fontsize=11)
+    ax.set_xlabel(xlabel, fontsize=11)
+    ax.legend(fontsize=9, loc='best')
+    ax.grid(True, alpha=0.3)
+    _configure_log_xticks(ax, all_ticks)
+
+
+def setup_ttft_ttfo_panel(ax, benchmarks, all_ticks: List[int], xlabel: str) -> None:
+    """TTFT panel, with TTFO (time to first output token) overlaid as a dashed
+    line when it meaningfully diverges from TTFT.
+
+    For non-reasoning models TTFO == TTFT, so the overlay is suppressed to avoid
+    drawing a redundant coincident line. For reasoning models the gap between the
+    solid (TTFT) and dashed (TTFO) lines is exactly the reasoning-preamble time.
+    """
+    def _diverges(b) -> bool:
+        for ttft, ttfo in zip(b.metrics['ttft_mean'], b.metrics['ttfo_mean']):
+            if ttfo > 0 and ttft > 0 and abs(ttfo - ttft) / ttft > 0.02:
+                return True
+        return False
+
+    show_ttfo = any(_diverges(b) for b in benchmarks)
+
+    for idx, benchmark in enumerate(benchmarks):
+        color = COLOR_PALETTE[idx % len(COLOR_PALETTE)]
+        marker = MARKER_STYLES[idx % len(MARKER_STYLES)]
+        x_values = benchmark.metrics['sweep_values']
+
+        ttft_label = f"{benchmark.label} TTFT" if show_ttfo else benchmark.label
+        plot_line_with_errorband(ax, x_values, benchmark.metrics['ttft_mean'],
+                                 benchmark.metrics['ttft_std'], color, marker, ttft_label)
+        add_annotations(ax, x_values, benchmark.metrics['ttft_mean'], idx,
+                       format_string='{:.2f}s')
+
+        if show_ttfo:
+            ax.plot(x_values, benchmark.metrics['ttfo_mean'], color=color, marker=marker,
+                    linestyle='--', markerfacecolor='none', alpha=0.9,
+                    label=f"{benchmark.label} TTFO")
+
+    title = ('Prefill Phase: TTFT (solid) vs TTFO (dashed)'
+             if show_ttfo else 'Prefill Phase: Time to First Token')
+    ax.set_title(title, fontsize=14, fontweight='bold', pad=20)
+    ax.set_ylabel('Seconds', fontsize=11)
     ax.set_xlabel(xlabel, fontsize=11)
     ax.legend(fontsize=9, loc='best')
     ax.grid(True, alpha=0.3)
@@ -429,10 +474,7 @@ def plot_multiple_benchmarks(data_sources: List[str], output_image: str) -> None
         gs = GridSpec(3, 2, hspace=0.35, wspace=0.3, height_ratios=[1, 1, 1])
 
         ax1 = fig.add_subplot(gs[0, 0])
-        setup_line_plot(ax1, benchmarks, all_ticks, xlabel,
-                        'ttft_mean', 'ttft_std',
-                        'Prefill Phase: Time to First Token',
-                        'TTFT (seconds)', '{:.2f}s')
+        setup_ttft_ttfo_panel(ax1, benchmarks, all_ticks, xlabel)
 
         ax2 = fig.add_subplot(gs[0, 1])
         setup_line_plot(ax2, benchmarks, all_ticks, xlabel,


### PR DESCRIPTION
Pulls the perf-critical streaming path closer to aiperf, which is more SOTA on measurement and HTTP handling. Three commits: correctness fixes, a fidelity tier, then the TTFO plot. All in `completion_benchmark.py` except the last.

## What changed

**Correctness (commit 1) — each of these moves the reported numbers:**
- **TTFT was measured after parsing.** First-token and per-token times were stamped after `json.loads` + the delta walk, so they baked in client-side parse + event-loop latency. Now the perf clock is stamped the instant a chunk lands off the socket, inside the SSE reader, before any parsing.
- **Reasoning was double-counted.** `output_tokens` was `reasoning_tokens + completion_tokens`, but vLLM/OpenAI/OpenRouter already fold reasoning into `completion_tokens` (OpenRouter nests it under `completion_tokens_details.reasoning_tokens`). Switched to `OSL = completion_tokens` (aiperf's semantic).
- **Latency ran one RTT long.** The window ended at the trailing usage/`[DONE]` chunk; now it ends at the last real content token (aiperf's request-latency = last content response).
- **A streamed `event: error` was scored as a success.** It parsed as a normal contentless chunk and the request counted as a short, successful response. Now detected and failed.
- **Only HTTP 200 was accepted.** Now the full 2xx range passes and the status is captured on every record. Also stops latching an empty `{}` usage object as real usage.

**Fidelity (commit 2):**
- Latency measured in monotonic `perf_counter_ns` (integer ns internally, seconds at the boundary).
- **TTFO** (time to first output token) — first non-reasoning token, distinct from TTFT. Plumbed through per-request results and the aggregation.
- Client-side tokenizer fallback when the server omits usage (uses the already-loaded tokenizer; `OSL = output + reasoning` text) instead of "1 chunk ≈ 1 token".
- TCP_NODELAY connector so Nagle doesn't coalesce small SSE frames, plus `skip_auto_headers` so response gzip doesn't add decode latency to chunk timing.

**Plot (commit 3):** TTFO overlaid on the TTFT panel (solid TTFT, dashed TTFO), suppressed when they coincide (non-reasoning). No layout change.

## Notes
- `OSL = completion_tokens` is the deliberate call: aiperf treats `completion_tokens` as already including reasoning. Confirmed against OpenRouter's live schema — `reasoning_tokens` is nested under `completion_tokens_details`, so the old top-level `reasoning_tokens` read was both wrong-keyed and additive.
- TCP_NODELAY goes through aiohttp's `socket_factory` (>=3.9) with a graceful fallback on older aiohttp.
- Per-request JSON timestamps and the phased-metric layer stay in seconds, so the on-disk schema is unchanged apart from the added `ttfo` fields.
- No version bump — left for whoever cuts the release.

## Validation

`python -m py_compile` clean. SSE reader smoke-tested against a fake response: JSON reassembled across a mid-object TCP split, `event: error` flagged, reasoning-vs-output delta split correct, `[DONE]` surfaced.

**Live before/after on `google/gemma-4-26b-a4b-it:free` (OpenRouter), streaming.** To remove network jitter from the delta, one timeline was recorded per request and *both* the old and new metric definitions were computed from the same data (mean over 5 distinct prompts, same token budget):

| metric | before | after | per-req delta |
|---|--:|--:|--:|
| TTFT (s) | 1.166 | 1.166 | ~0 |
| decode time (s) | 0.783 | 0.712 | **−0.070** |
| TPOT (s) | 0.0123 | 0.0121 | −0.0002 |
| tok/s/user | 65.3 | 66.1 | +0.81 |
| output tokens | 48.0 | 48.0 | 0 |

- The **latency-window fix** removes a mean **~70 ms/request** (range 0.1–295 ms) of trailing usage/`[DONE]`+socket-close tail — deterministic, raises per-user decode throughput.
- **TTFT parse-cost delta is ~0** on a remote endpoint (parse is microseconds; arrival-stamping matters under high concurrency / fast local servers).
- **Output tokens identical** — gemma is non-reasoning, so nothing to double-count. The reasoning fix only bites reasoning models.

A separate two-run network comparison (one full benchmark on each branch) showed the same direction: decode throughput/user 70.3 → 82.5 tok/s, decode time 0.634 → 0.574 s, with E2E TPS and token counts flat.

## Extended usage fields (commit 4)

tokenomics read only `prompt_tokens` + `completion_tokens` and dropped everything else OpenAI-compatible servers report. Now parses the perf-relevant extras aiperf already tracks, gated on presence so plain servers are unaffected:

| field | source | surfaced as |
|---|---|---|
| `reasoning_tokens` | `completion_tokens_details` (nested) or top-level | mean/std/total |
| `cached_tokens` | `prompt_tokens_details` | total + derived `cache_hit_rate` |
| `cost` / `total_tokens` | `usage` | mean/total |
| `finish_reason` / `native_finish_reason` | choices | counts (truncation detection) |
| `provider` | top-level | counts |

Flows into a `usage_extras` block per request → aggregated into each sweep's result JSON → short "Server Usage Extras" console summary. Verified live against OpenRouter: `finish_reasons {'length': N}` (all truncated at max_tokens) and `providers {'Google AI Studio': N}` captured; reasoning/cache/cost zero for non-reasoning gemma as expected.
