### PR TITLE
Dataset-replay mode + --ignore-eos for real-prompt throughput benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Bundled configs under `examples/dataset_configs/`:
 | `alpaca.json` | `tatsu-lab/alpaca_eval` (eval) | instruction following (AlpacaEval) |
 | `arena_hard.json` | `lmarena-ai/arena-hard-auto-v0.1` (train) | hard instruction following (Arena-Hard) |
 
-**`--ignore-eos`** generates exactly `--max-tokens` per request (SGLang). Add it when comparing harnesses, servers, or configs: it fixes output length so throughput isn't skewed by content-dependent token counts — which, on batch-non-invariant models (bf16 MoE on AMD), can differ ~15–20% between runs. With it, tokenomics matches SpecForge's `bench_eagle3.py` within 1–3% (LFM2.5-8B-A1B, MI325X, concurrency 8/16/32). Omit it for realistic, content-driven lengths.
+**`--ignore-eos`** makes every request generate exactly `--max-tokens` (EOS ignored), fixing output length so throughput isn't skewed by content-dependent token counts. Add it when comparing harnesses, servers, or configs; omit it for realistic, content-driven lengths. Supported by SGLang and vLLM — servers that don't implement it ignore the field, so it silently has no effect there.
 
 ### Key Options
 
@@ -159,7 +159,7 @@ Bundled configs under `examples/dataset_configs/`:
 | `--num-prompts` | Prompts per sweep point in sustained mode |
 | `--num-runs` | Runs per sweep point (default: 3) |
 | `--max-tokens` | Max output tokens (default: 4096) |
-| `--ignore-eos` | Generate exactly `--max-tokens` per request, ignoring EOS (SGLang). Fixes output length for clean cross-harness throughput comparison |
+| `--ignore-eos` | Generate exactly `--max-tokens` per request, ignoring EOS (SGLang/vLLM). Fixes output length for clean cross-harness throughput comparison |
 | `-n` | Completions per request (default: 1) |
 | `--stream` | Enable SSE streaming for TTFT/per-token metrics |
 | `--dataset-config` | Path to dataset config (default: bundled AIME) |

--- a/README.md
+++ b/README.md
@@ -115,25 +115,22 @@ See `examples/dataset_configs/` for more examples.
 
 ### Dataset Replay Mode
 
-By default the benchmark *synthesizes* prompts — it concatenates random dataset snippets until it hits the scenario's input-token budget. That's fine for raw throughput curves at controlled input/output lengths, but the prompts are stitched-together fragments, so the generated content isn't representative of any real workload. When you want throughput on the *actual* examples in a dataset — and to compare one dataset against another — use replay mode.
-
-`--replay-dataset` sends real examples one at a time:
-
-- Each dataset row is sent **verbatim as one request** — no concatenation, no length padding.
-- The benchmark **walks the dataset in order**, generating to natural EOS capped by `--max-tokens`.
-- The prompt set is **pinned**: identical rows in the same order across every concurrency level and run, so results are comparable example by example.
+`--replay-dataset` sends each dataset row **verbatim as one request** and walks the dataset in order at each concurrency level, instead of synthesizing prompts to the scenario's token budget. Use it to benchmark on real examples and compare datasets. The prompt set is pinned (same rows, same order across every concurrency and run), so results line up example by example.
 
 ```bash
 tokenomics completion \
   --replay-dataset \
   --dataset-config examples/dataset_configs/humaneval.json \
   --model your-model \
-  --max-concurrency 1,2,4,8,16,32 \
-  --max-tokens 1024 \
+  --max-concurrency 1,2,4,8,16,32 --max-tokens 1024 \
   --results-dir results/humaneval/
 ```
 
-Bundled real-dataset configs for replay (under `examples/dataset_configs/`) — common code, math, and QA evaluation sets, each sending its prompt column verbatim:
+- Sustained mode only (`--max-concurrency`); `--scenario` is ignored.
+- `--num-prompts N` caps the walk to the first N rows (default: whole dataset).
+- List prompt columns (MT-Bench `prompt`, Arena-Hard `turns`) are reduced to the first turn's string — MT-Bench runs single-turn.
+
+Bundled configs under `examples/dataset_configs/`:
 
 | Config | Dataset | Domain |
 |--------|---------|--------|
@@ -147,32 +144,7 @@ Bundled real-dataset configs for replay (under `examples/dataset_configs/`) — 
 | `alpaca.json` | `tatsu-lab/alpaca_eval` (eval) | instruction following (AlpacaEval) |
 | `arena_hard.json` | `lmarena-ai/arena-hard-auto-v0.1` (train) | hard instruction following (Arena-Hard) |
 
-A prompt column that holds a list (MT-Bench's `prompt`, Arena-Hard's `turns`) is reduced to a single string — the first turn (and its `content` field, for turn-dicts). MT-Bench is therefore benchmarked single-turn.
-
-Notes:
-
-- `--scenario` is **not used** in this mode (input length comes from the data); only `--max-tokens` bounds the output.
-- Requires `--max-concurrency` (sustained mode). Burst mode is rejected — it would walk a different slice of the dataset at each sweep point and break the comparison.
-- `--num-prompts N` caps the walk to the first `N` rows; the default is the whole dataset.
-- To compare datasets, run once per config and overlay the results with `tokenomics plot-completion ...`. To compare two servers or server configs, run the same matrix against each and overlay — tokenomics stays a pure OpenAI client and measures only what it observes over the wire.
-
-#### Fixed-length comparison (`--ignore-eos`)
-
-Natural-EOS replay (above) is the realistic measurement — report it as the model's throughput on a dataset. But it's the wrong tool when you need to **compare two harnesses, servers, or configs**: the *total* output token count then depends on the generated content, which drifts between runs. On models with **batch-non-invariant decode** (e.g. bf16 MoE on AMD), the same prompt set even produces different total tokens depending on how requests happen to batch — so two tools can report throughputs ~15–20% apart purely from generating different *amounts*, not from measuring differently.
-
-`--ignore-eos` removes that variable: every request generates **exactly `--max-tokens`**, so the workload is identical run-to-run and throughput reflects pure serving speed. Validated against [SpecForge](https://github.com/sgl-project/SpecForge)'s `bench_eagle3.py` on the same SGLang server (LFM2.5-8B-A1B, MI325X): with `--ignore-eos` the two agree within **1–3%** across concurrency 8/16/32; without it they diverged ~17%, entirely from batch-non-invariant token counts.
-
-```bash
-tokenomics completion \
-  --replay-dataset \
-  --dataset-config examples/dataset_configs/humaneval.json \
-  --model your-model \
-  --max-concurrency 8,16,32 \
-  --max-tokens 1024 --ignore-eos --temperature 0 \
-  --results-dir results/humaneval/
-```
-
-`--ignore-eos` is SGLang-specific (sent as a top-level request field). Use it for apples-to-apples throughput; omit it when you want realistic, content-driven generation lengths.
+**`--ignore-eos`** generates exactly `--max-tokens` per request (SGLang). Add it when comparing harnesses, servers, or configs: it fixes output length so throughput isn't skewed by content-dependent token counts — which, on batch-non-invariant models (bf16 MoE on AMD), can differ ~15–20% between runs. With it, tokenomics matches SpecForge's `bench_eagle3.py` within 1–3% (LFM2.5-8B-A1B, MI325X, concurrency 8/16/32). Omit it for realistic, content-driven lengths.
 
 ### Key Options
 

--- a/README.md
+++ b/README.md
@@ -137,10 +137,17 @@ Bundled real-dataset configs for replay (under `examples/dataset_configs/`) — 
 
 | Config | Dataset | Domain |
 |--------|---------|--------|
-| `humaneval.json` | `openai/openai_humaneval` (test) | code completion |
-| `mbpp.json` | `google-research-datasets/mbpp` sanitized (test) | code generation |
 | `gsm8k.json` | `openai/gsm8k` main (test) | grade-school math |
-| `math500.json` | `HuggingFaceH4/MATH-500` (test) | competition math |
+| `math500.json` | `HuggingFaceH4/MATH-500` (test) | competition math (MATH) |
+| `aime25.json` | `math-ai/aime25` (test) | competition math (AIME 2025) |
+| `mbpp.json` | `google-research-datasets/mbpp` sanitized (test) | code generation |
+| `humaneval.json` | `openai/openai_humaneval` (test) | code completion |
+| `lcb.json` | `livecodebench/code_generation_lite` release_v1 (test) | code generation (LiveCodeBench) |
+| `mtbench.json` | `HuggingFaceH4/mt_bench_prompts` (train) | multi-turn chat (first turn) |
+| `alpaca.json` | `tatsu-lab/alpaca_eval` (eval) | instruction following (AlpacaEval) |
+| `arena_hard.json` | `lmarena-ai/arena-hard-auto-v0.1` (train) | hard instruction following (Arena-Hard) |
+
+A prompt column that holds a list (MT-Bench's `prompt`, Arena-Hard's `turns`) is reduced to a single string — the first turn (and its `content` field, for turn-dicts). MT-Bench is therefore benchmarked single-turn.
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ tokenomics completion \
   --model your-model \
   --max-concurrency 1,2,4,8 \
   --stream
+
+# Dataset-replay mode — walk a real dataset example by example (no --scenario)
+tokenomics completion \
+  --replay-dataset \
+  --dataset-config examples/dataset_configs/humaneval.json \
+  --model your-model \
+  --max-concurrency 1,2,4,8,16,32 \
+  --max-tokens 1024
 ```
 
 The two execution modes (`--batch-sizes` and `--max-concurrency`) are mutually exclusive. Burst is good for peak throughput; sustained gives realistic production numbers.
@@ -105,11 +113,66 @@ File paths are resolved relative to the config file.
 
 See `examples/dataset_configs/` for more examples.
 
+### Dataset Replay Mode
+
+By default the benchmark *synthesizes* prompts — it concatenates random dataset snippets until it hits the scenario's input-token budget. That's fine for raw throughput curves at controlled input/output lengths, but the prompts are stitched-together fragments, so the generated content isn't representative of any real workload. When you want throughput on the *actual* examples in a dataset — and to compare one dataset against another — use replay mode.
+
+`--replay-dataset` sends real examples one at a time:
+
+- Each dataset row is sent **verbatim as one request** — no concatenation, no length padding.
+- The benchmark **walks the dataset in order**, generating to natural EOS capped by `--max-tokens`.
+- The prompt set is **pinned**: identical rows in the same order across every concurrency level and run, so results are comparable example by example.
+
+```bash
+tokenomics completion \
+  --replay-dataset \
+  --dataset-config examples/dataset_configs/humaneval.json \
+  --model your-model \
+  --max-concurrency 1,2,4,8,16,32 \
+  --max-tokens 1024 \
+  --results-dir results/humaneval/
+```
+
+Bundled real-dataset configs for replay (under `examples/dataset_configs/`) — common code, math, and QA evaluation sets, each sending its prompt column verbatim:
+
+| Config | Dataset | Domain |
+|--------|---------|--------|
+| `humaneval.json` | `openai/openai_humaneval` (test) | code completion |
+| `mbpp.json` | `google-research-datasets/mbpp` sanitized (test) | code generation |
+| `gsm8k.json` | `openai/gsm8k` main (test) | grade-school math |
+| `math500.json` | `HuggingFaceH4/MATH-500` (test) | competition math |
+
+Notes:
+
+- `--scenario` is **not used** in this mode (input length comes from the data); only `--max-tokens` bounds the output.
+- Requires `--max-concurrency` (sustained mode). Burst mode is rejected — it would walk a different slice of the dataset at each sweep point and break the comparison.
+- `--num-prompts N` caps the walk to the first `N` rows; the default is the whole dataset.
+- To compare datasets, run once per config and overlay the results with `tokenomics plot-completion ...`. To compare two servers or server configs, run the same matrix against each and overlay — tokenomics stays a pure OpenAI client and measures only what it observes over the wire.
+
+#### Fixed-length comparison (`--ignore-eos`)
+
+Natural-EOS replay (above) is the realistic measurement — report it as the model's throughput on a dataset. But it's the wrong tool when you need to **compare two harnesses, servers, or configs**: the *total* output token count then depends on the generated content, which drifts between runs. On models with **batch-non-invariant decode** (e.g. bf16 MoE on AMD), the same prompt set even produces different total tokens depending on how requests happen to batch — so two tools can report throughputs ~15–20% apart purely from generating different *amounts*, not from measuring differently.
+
+`--ignore-eos` removes that variable: every request generates **exactly `--max-tokens`**, so the workload is identical run-to-run and throughput reflects pure serving speed. Validated against [SpecForge](https://github.com/sgl-project/SpecForge)'s `bench_eagle3.py` on the same SGLang server (LFM2.5-8B-A1B, MI325X): with `--ignore-eos` the two agree within **1–3%** across concurrency 8/16/32; without it they diverged ~17%, entirely from batch-non-invariant token counts.
+
+```bash
+tokenomics completion \
+  --replay-dataset \
+  --dataset-config examples/dataset_configs/humaneval.json \
+  --model your-model \
+  --max-concurrency 8,16,32 \
+  --max-tokens 1024 --ignore-eos --temperature 0 \
+  --results-dir results/humaneval/
+```
+
+`--ignore-eos` is SGLang-specific (sent as a top-level request field). Use it for apples-to-apples throughput; omit it when you want realistic, content-driven generation lengths.
+
 ### Key Options
 
 | Flag | Description |
 |------|-------------|
-| `--scenario` | Traffic pattern (required) |
+| `--scenario` | Traffic pattern (required unless `--replay-dataset`) |
+| `--replay-dataset` | Send each dataset row verbatim and walk the dataset at each concurrency level (ignores `--scenario`; sustained mode only) |
 | `--model` | Model name (required) |
 | `--api-base` | Server URL (default: `http://localhost:8000/v1`) |
 | `--batch-sizes` | Burst mode sweep points |
@@ -117,6 +180,7 @@ See `examples/dataset_configs/` for more examples.
 | `--num-prompts` | Prompts per sweep point in sustained mode |
 | `--num-runs` | Runs per sweep point (default: 3) |
 | `--max-tokens` | Max output tokens (default: 4096) |
+| `--ignore-eos` | Generate exactly `--max-tokens` per request, ignoring EOS (SGLang). Fixes output length for clean cross-harness throughput comparison |
 | `-n` | Completions per request (default: 1) |
 | `--stream` | Enable SSE streaming for TTFT/per-token metrics |
 | `--dataset-config` | Path to dataset config (default: bundled AIME) |

--- a/examples/dataset_configs/aime25.json
+++ b/examples/dataset_configs/aime25.json
@@ -1,0 +1,9 @@
+{
+  "source": {
+    "type": "huggingface",
+    "path": "math-ai/aime25",
+    "huggingface_kwargs": { "split": "test" }
+  },
+  "prompt_column": "problem",
+  "description": "AIME 2025 competition math problems (30 problems). Each problem statement is sent verbatim. Use with --replay-dataset."
+}

--- a/examples/dataset_configs/alpaca.json
+++ b/examples/dataset_configs/alpaca.json
@@ -1,0 +1,9 @@
+{
+  "source": {
+    "type": "huggingface",
+    "path": "tatsu-lab/alpaca_eval",
+    "huggingface_kwargs": { "name": "alpaca_eval", "split": "eval", "trust_remote_code": true }
+  },
+  "prompt_column": "instruction",
+  "description": "AlpacaEval instructions (805 instruction-following prompts). Each instruction is sent verbatim. Use with --replay-dataset."
+}

--- a/examples/dataset_configs/arena_hard.json
+++ b/examples/dataset_configs/arena_hard.json
@@ -1,0 +1,9 @@
+{
+  "source": {
+    "type": "huggingface",
+    "path": "lmarena-ai/arena-hard-auto-v0.1",
+    "huggingface_kwargs": { "split": "train", "trust_remote_code": true }
+  },
+  "prompt_column": "turns",
+  "description": "Arena-Hard-Auto v0.1 prompts (500 hard questions). The turns column is a list of {content}; the first turn's content is sent. Use with --replay-dataset."
+}

--- a/examples/dataset_configs/gsm8k.json
+++ b/examples/dataset_configs/gsm8k.json
@@ -1,0 +1,9 @@
+{
+  "source": {
+    "type": "huggingface",
+    "path": "openai/gsm8k",
+    "huggingface_kwargs": { "name": "main", "split": "test" }
+  },
+  "prompt_column": "question",
+  "description": "GSM8K grade-school math word problems (test split). Each row's question is sent verbatim. Pair with --replay-dataset."
+}

--- a/examples/dataset_configs/humaneval.json
+++ b/examples/dataset_configs/humaneval.json
@@ -1,0 +1,9 @@
+{
+  "source": {
+    "type": "huggingface",
+    "path": "openai/openai_humaneval",
+    "huggingface_kwargs": { "split": "test" }
+  },
+  "prompt_column": "prompt",
+  "description": "HumanEval code-completion prompts. Use with --replay-dataset to benchmark on real examples one at a time."
+}

--- a/examples/dataset_configs/lcb.json
+++ b/examples/dataset_configs/lcb.json
@@ -1,0 +1,9 @@
+{
+  "source": {
+    "type": "huggingface",
+    "path": "livecodebench/code_generation_lite",
+    "huggingface_kwargs": { "name": "release_v1", "split": "test", "trust_remote_code": true }
+  },
+  "prompt_column": "question_content",
+  "description": "LiveCodeBench code-generation problems (release_v1). Each problem statement is sent verbatim. Use with --replay-dataset."
+}

--- a/examples/dataset_configs/math500.json
+++ b/examples/dataset_configs/math500.json
@@ -1,0 +1,9 @@
+{
+  "source": {
+    "type": "huggingface",
+    "path": "HuggingFaceH4/MATH-500",
+    "huggingface_kwargs": { "split": "test" }
+  },
+  "prompt_column": "problem",
+  "description": "MATH-500 competition math problems (test split). Each row's problem statement is sent verbatim. Pair with --replay-dataset."
+}

--- a/examples/dataset_configs/mbpp.json
+++ b/examples/dataset_configs/mbpp.json
@@ -1,0 +1,9 @@
+{
+  "source": {
+    "type": "huggingface",
+    "path": "google-research-datasets/mbpp",
+    "huggingface_kwargs": { "name": "sanitized", "split": "test" }
+  },
+  "prompt_column": "prompt",
+  "description": "MBPP sanitized split. Each row's natural-language task prompt is sent verbatim. Use with --replay-dataset."
+}

--- a/examples/dataset_configs/mtbench.json
+++ b/examples/dataset_configs/mtbench.json
@@ -1,0 +1,9 @@
+{
+  "source": {
+    "type": "huggingface",
+    "path": "HuggingFaceH4/mt_bench_prompts",
+    "huggingface_kwargs": { "split": "train" }
+  },
+  "prompt_column": "prompt",
+  "description": "MT-Bench prompts (80 multi-turn questions). The prompt column is a list of turns; the first turn is sent (single-turn benchmark). Use with --replay-dataset."
+}

--- a/tokenomics/__init__.py
+++ b/tokenomics/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 from pathlib import Path
 

--- a/tokenomics/completion_benchmark.py
+++ b/tokenomics/completion_benchmark.py
@@ -275,8 +275,9 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
         "stream": stream,
     }
     if request_data.get("ignore_eos"):
-        # SGLang-specific: generate exactly max_tokens, ignoring EOS. Makes the
-        # output length fixed/identical across runs for clean throughput parity.
+        # Generate exactly max_tokens, ignoring EOS (supported by SGLang/vLLM;
+        # ignored by servers that don't implement it). Fixes output length so
+        # throughput comparisons aren't skewed by content-dependent token counts.
         payload["ignore_eos"] = True
     if stream:
         payload["stream_options"] = {"include_usage": True}
@@ -831,7 +832,7 @@ def main():
     parser.add_argument("--warmup-runs", type=int, default=3, help="Number of warmup runs before each sweep point")
     parser.add_argument("--temperature", type=float, default=0.7, help="Temperature parameter")
     parser.add_argument("--max-tokens", type=int, default=4096, help="Upper bound on max_tokens per request (default: 4096)")
-    parser.add_argument("--ignore-eos", action="store_true", help="Ignore EOS and generate exactly max_tokens per request (SGLang). Fixes output length for clean throughput comparison.")
+    parser.add_argument("--ignore-eos", action="store_true", help="Ignore EOS and generate exactly max_tokens per request (SGLang/vLLM; a no-op on servers that don't support it). Fixes output length for clean throughput comparison.")
     parser.add_argument("-n", "--num-completions", type=int, default=1, help="Number of completions per request (default: 1)")
     parser.add_argument("--stream", action="store_true", help="Enable streaming (for TTFT/per-token metrics, lower throughput)")
     parser.add_argument("--description", default="Benchmark", help="Description of the benchmark")

--- a/tokenomics/completion_benchmark.py
+++ b/tokenomics/completion_benchmark.py
@@ -23,7 +23,7 @@ NS_PER_SECOND = 1_000_000_000
 os.environ["HF_DATASETS_DISABLE_PROGRESS_BARS"] = "1"
 os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
 
-from .sampling import Scenario, TextSampler, DatasetConfig, DatasetLoader, use_seed, derive_seed
+from .sampling import Scenario, TextSampler, DatasetReplaySampler, DatasetConfig, DatasetLoader, use_seed, derive_seed
 from .io import round_floats, atomic_write_json
 
 
@@ -274,6 +274,10 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
         "temperature": temperature,
         "stream": stream,
     }
+    if request_data.get("ignore_eos"):
+        # SGLang-specific: generate exactly max_tokens, ignoring EOS. Makes the
+        # output length fixed/identical across runs for clean throughput parity.
+        payload["ignore_eos"] = True
     if stream:
         payload["stream_options"] = {"include_usage": True}
     if n > 1:
@@ -810,7 +814,9 @@ def main():
     parser.add_argument("--model", required=True, help="Model name")
     
     # Scenario configuration
-    parser.add_argument("--scenario", required=True, help="Scenario string (e.g., 'N(480,240)/(300,150)', 'D(100,100)')")
+    parser.add_argument("--scenario", default=None, help="Scenario string (e.g., 'N(480,240)/(300,150)', 'D(100,100)'). Required unless --replay-dataset is set.")
+    parser.add_argument("--replay-dataset", action="store_true",
+                        help="Send each dataset row verbatim as one request and walk the whole dataset at each concurrency level, instead of synthesizing prompts to the scenario's token budget. Ignores the scenario's input length; output is capped by --max-tokens and otherwise runs to natural EOS. Requires --max-concurrency (sustained mode).")
     parser.add_argument("--dataset-config", default=None, help="Path to dataset configuration JSON (defaults to bundled AIME dataset)")
     parser.add_argument("--tokenizer", help="Tokenizer name (defaults to model name)")
     parser.add_argument("--seed", type=int, default=42, help="Base seed for deterministic sampling")
@@ -825,6 +831,7 @@ def main():
     parser.add_argument("--warmup-runs", type=int, default=3, help="Number of warmup runs before each sweep point")
     parser.add_argument("--temperature", type=float, default=0.7, help="Temperature parameter")
     parser.add_argument("--max-tokens", type=int, default=4096, help="Upper bound on max_tokens per request (default: 4096)")
+    parser.add_argument("--ignore-eos", action="store_true", help="Ignore EOS and generate exactly max_tokens per request (SGLang). Fixes output length for clean throughput comparison.")
     parser.add_argument("-n", "--num-completions", type=int, default=1, help="Number of completions per request (default: 1)")
     parser.add_argument("--stream", action="store_true", help="Enable streaming (for TTFT/per-token metrics, lower throughput)")
     parser.add_argument("--description", default="Benchmark", help="Description of the benchmark")
@@ -855,6 +862,15 @@ def main():
         execution_mode = "burst"
         sweep_values = [int(x.strip()) for x in (args.batch_sizes or "1,2,4,8").split(",")]
 
+    # Replay mode walks a fixed dataset at each concurrency level; the scenario is
+    # irrelevant (the row content is the prompt) and burst mode would walk a
+    # different prefix per sweep value, breaking the apples-to-apples comparison.
+    if args.replay_dataset:
+        if execution_mode != "sustained":
+            parser.error("--replay-dataset requires --max-concurrency (sustained mode)")
+    elif args.scenario is None:
+        parser.error("--scenario is required unless --replay-dataset is set")
+
     # Create LoRA config from command-line arguments
     lora_config = None
     if args.lora_strategy and args.lora_names:
@@ -868,7 +884,7 @@ def main():
         print(f"🔧 LoRA config: strategy={lora_config.strategy}, {len(lora_config.lora_names)} LoRAs, base_model_ratio={lora_config.base_model_ratio}")
 
     # Initialize scenario and dataset
-    scenario = Scenario.from_string(args.scenario)
+    scenario = None if args.replay_dataset else Scenario.from_string(args.scenario)
     if args.dataset_config is None:
         from tokenomics import EXAMPLES_DIR
         args.dataset_config = str(EXAMPLES_DIR / "dataset_configs" / "aime_simple.json")
@@ -877,7 +893,10 @@ def main():
 
     tokenizer_name = args.tokenizer or args.model
 
-    text_sampler = TextSampler(tokenizer_name, dataset_loader)
+    if args.replay_dataset:
+        text_sampler = DatasetReplaySampler(tokenizer_name, dataset_loader, args.max_tokens)
+    else:
+        text_sampler = TextSampler(tokenizer_name, dataset_loader)
 
     def count_output_tokens(text: str) -> int:
         """Client-side output-token count used when the server omits usage."""
@@ -888,7 +907,10 @@ def main():
         except Exception:
             return int(len(text.split()) * 1.3)
 
-    print(f"📊 Initialized benchmark with scenario: {args.scenario}")
+    if args.replay_dataset:
+        print(f"📊 Initialized benchmark in dataset-replay mode (max_tokens={args.max_tokens})")
+    else:
+        print(f"📊 Initialized benchmark with scenario: {args.scenario}")
     print(f"📚 Loaded dataset: {len(dataset_loader)} samples")
     print(f"⚙️  Execution mode: {execution_mode}")
     if lora_config:
@@ -900,6 +922,8 @@ def main():
         "timestamp": datetime.now().isoformat(),
         "model": args.model,
         "scenario": args.scenario,
+        "prompt_source": "dataset_replay" if args.replay_dataset else "scenario",
+        "max_tokens": args.max_tokens,
         "dataset_config": dataset_config.config,
         "api_base": args.api_base,
         "execution_mode": execution_mode,
@@ -931,7 +955,12 @@ def main():
     # Run benchmark for each sweep value
     for sweep_value in sweep_values:
         if execution_mode == "sustained":
-            num_prompts = args.num_prompts or max(64, 8 * sweep_value)
+            if args.replay_dataset:
+                # Fixed prompt set = the dataset (or first --num-prompts rows),
+                # identical across every concurrency level for a fair comparison.
+                num_prompts = min(args.num_prompts or len(dataset_loader), len(dataset_loader))
+            else:
+                num_prompts = args.num_prompts or max(64, 8 * sweep_value)
             max_concurrency = sweep_value
             print(f"\n🔄 Testing concurrency: {sweep_value} ({num_prompts} prompts)")
         else:
@@ -968,6 +997,8 @@ def main():
                 }
                 if lora_assignments:
                     request_dict["lora_name"] = lora_assignments[idx]
+                if args.ignore_eos:
+                    request_dict["ignore_eos"] = True
                 user_requests.append(request_dict)
 
             run_data = run_benchmark_batch(

--- a/tokenomics/sampling/__init__.py
+++ b/tokenomics/sampling/__init__.py
@@ -6,7 +6,7 @@ statistical parameter generation from content sampling.
 """
 
 from .scenarios import Scenario, NormalDistribution, DeterministicDistribution, UniformDistribution
-from .sampler import TextSampler, UserRequest, use_seed, derive_seed
+from .sampler import TextSampler, DatasetReplaySampler, UserRequest, use_seed, derive_seed
 from .dataset import DatasetConfig, DatasetLoader
 
 __all__ = [
@@ -15,6 +15,7 @@ __all__ = [
     'DeterministicDistribution',
     'UniformDistribution',
     'TextSampler',
+    'DatasetReplaySampler',
     'UserRequest',
     'use_seed',
     'derive_seed',

--- a/tokenomics/sampling/dataset.py
+++ b/tokenomics/sampling/dataset.py
@@ -13,6 +13,25 @@ from typing import List, Dict, Any, Optional, Union
 from datasets import load_dataset
 
 
+def _coerce_prompt(value: Any) -> str:
+    """Reduce a prompt-column value to a single string.
+
+    Handles plain strings, multi-turn list columns (e.g. MT-Bench ``prompt`` is
+    a list of turn strings -> first turn), and list-of-dict columns (e.g.
+    Arena-Hard ``turns`` is ``[{"content": ...}]`` -> first turn's content).
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return value.get("content") or value.get("value") or value.get("text") or ""
+    if isinstance(value, list) and value:
+        first = value[0]
+        if isinstance(first, dict):
+            return first.get("content") or first.get("value") or first.get("text") or ""
+        return str(first)
+    return str(value) if value is not None else ""
+
+
 class DatasetConfig:
     """Configuration for dataset loading."""
     
@@ -121,8 +140,10 @@ class DatasetLoader:
 
             for item in data_split:
                 if self.config.prompt_column in item:
-                    self.data.append(item[self.config.prompt_column])
-                    
+                    text = _coerce_prompt(item[self.config.prompt_column])
+                    if text:
+                        self.data.append(text)
+
         except Exception as e:
             raise RuntimeError(f"Failed to load HuggingFace dataset: {e}")
     

--- a/tokenomics/sampling/dataset.py
+++ b/tokenomics/sampling/dataset.py
@@ -108,13 +108,17 @@ class DatasetLoader:
         
         try:
             dataset = load_dataset(dataset_name, **kwargs)
-            
-            # Handle different dataset structures
-            if "train" in dataset:
-                data_split = dataset["train"]
+
+            # load_dataset returns a bare Dataset when `split` is given, or a
+            # DatasetDict (split name -> Dataset) otherwise. Handle both.
+            if hasattr(dataset, "keys"):
+                if "train" in dataset:
+                    data_split = dataset["train"]
+                else:
+                    data_split = dataset[list(dataset.keys())[0]]
             else:
-                data_split = dataset[list(dataset.keys())[0]]
-            
+                data_split = dataset
+
             for item in data_split:
                 if self.config.prompt_column in item:
                     self.data.append(item[self.config.prompt_column])

--- a/tokenomics/sampling/sampler.py
+++ b/tokenomics/sampling/sampler.py
@@ -72,8 +72,53 @@ class TextSampler:
             return len(self.tokenizer.encode(text, add_special_tokens=True).ids)
         except Exception:
             return int(len(text.split()) * 1.3)
-    
-    
+
+
+class DatasetReplaySampler:
+    """Sends each dataset row verbatim as one request, walking the dataset in order.
+
+    The prompt *is* the dataset row
+    (no scenario-driven length padding, no concatenation of random snippets), and
+    generation runs to natural EOS capped by ``max_tokens``. Rows are returned
+    deterministically in dataset order, so the prompt set is identical across every
+    concurrency level and run -- which is what makes throughput comparable example
+    by example. It implements the same ``sample_batch`` / ``tokenizer`` surface as
+    :class:`TextSampler`, so it is a drop-in replacement in the benchmark loop.
+    """
+
+    def __init__(self, tokenizer_name: str, dataset_loader: DatasetLoader, max_tokens: int):
+        self.tokenizer = Tokenizer.from_pretrained(tokenizer_name)
+        self.dataset_loader = dataset_loader
+        self.max_tokens = max_tokens
+        self.rows = dataset_loader.get_all_texts()
+        if not self.rows:
+            raise ValueError("Dataset is empty")
+
+    def _count_tokens(self, text: str) -> int:
+        try:
+            return len(self.tokenizer.encode(text, add_special_tokens=True).ids)
+        except Exception:
+            return int(len(text.split()) * 1.3)
+
+    def sample_batch(self, scenario: Scenario, batch_size: int) -> List[UserRequest]:
+        """Return the first ``batch_size`` rows verbatim, in dataset order.
+
+        ``scenario`` is accepted for interface compatibility with
+        :class:`TextSampler` but ignored -- the row content defines the prompt.
+        If ``batch_size`` exceeds the dataset size it is capped (we walk the
+        dataset once, never cycle). ``target_output_tokens`` carries max_tokens
+        so the benchmark loop's ``min(args.max_tokens, target_output_tokens)``
+        resolves to max_tokens; generation still stops at EOS (unless
+        --ignore-eos).
+        """
+        out = []
+        for i in range(min(batch_size, len(self.rows))):
+            text = self.rows[i]
+            n_tok = self._count_tokens(text)
+            out.append(UserRequest(text, self.max_tokens, n_tok, n_tok, self.max_tokens))
+        return out
+
+
 @contextlib.contextmanager
 def use_seed(seed: int):
     state = random.getstate()


### PR DESCRIPTION
## What

Two additions for benchmarking on **real dataset prompts** instead of synthetic length-padded ones, plus a loader fix.

### `--replay-dataset`
Sends each dataset row **verbatim as one request** and walks the whole dataset at each concurrency level, instead of concatenating random snippets to a scenario's token budget. The prompt set is **pinned** — identical rows in the same order across every concurrency level and run — so results are comparable example by example.

- Sustained mode only (`--max-concurrency`); burst is rejected (it would walk a different slice per sweep point).
- `--scenario` is optional in this mode (input length comes from the data).
- `--num-prompts N` caps the walk to the first N rows; default is the whole dataset.
- Implemented as a drop-in `DatasetReplaySampler`, so the benchmark loop is essentially unchanged.

### `--ignore-eos`
Generates **exactly `--max-tokens`** per request (EOS ignored), fixing output length so throughput comparisons across harnesses/servers/configs aren't skewed by content-dependent token counts. SGLang-specific (top-level request field).

### Loader fix
`DatasetLoader` assumed `load_dataset` always returns a `DatasetDict` and called `.keys()` — it crashed on the bare `Dataset` returned when a config specifies `split`. Now handles both. (This also unbroke the existing `huggingface_squad.json` example.)

### Bundled replay configs
`humaneval`, `mbpp`, `gsm8k`, `math500` — common code/math/QA sets, each sending its prompt column verbatim.

## Validation
Cross-checked replay + `--ignore-eos` against SpecForge's `bench_eagle3.py` on the same SGLang server (LFM2.5-8B-A1B, MI325X). With fixed-length output the two harnesses' end-to-end throughput agree within **1–3%** across concurrency 8/16/32:

| concurrency | tokenomics | SpecForge | diff |
|---|---|---|---|
| 8 | 1888 tok/s | 1911 tok/s | 1.2% |
| 16 | 3067 tok/s | 2976 tok/s | 3.1% |
| 32 | 4886 tok/s | 4954 tok/s | 1.4% |

(Without `--ignore-eos` they diverge ~17%, entirely from different total token counts under batch-non-invariant decode — not a measurement discrepancy.)

## Notes
- No new dependencies; no changes to the request/metrics/plotting paths.
- README updated with both modes.