### PR TITLE
Add image/multimodal (VL) support to completion benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Image runs default to a short workload (the images dominate, the text is padding
 - `--input-tokens` sets the filler length (`0` = images only). `--image-size` is `N` for a square or `WxH` for a rectangle — e.g. `--image-size 512` (512×512) or `--image-size 1024x768` (width × height, lowercase `x`, no spaces).
 - Synthetic images are random-noise PNGs built on the fly, seeded per request so they're **unique** (defeating the server's prefix/multimodal caches) yet reproducible. Note noise is nearly incompressible (~MBs at 1024×1024), so keep image size/count sane or the payload dominates.
 - Sweep image size/count/text-length by looping the command (one `--results-dir` each) and overlaying with `plot-completion` — nothing is baked in.
-- Pass an explicit `--scenario` instead to drive the text from the dataset sampler (e.g. images on top of realistic prompts).
+- `--input-tokens` and `--scenario` are mutually exclusive (both set text length) — pass `--scenario` instead to drive the text from the dataset sampler (e.g. images on top of realistic prompts).
 
 ### Key Options
 

--- a/README.md
+++ b/README.md
@@ -148,20 +148,22 @@ Bundled configs under `examples/dataset_configs/`:
 
 ### Vision / multimodal
 
-Attach images to every request with `--num-images` and `--image-size`, turning any completion run into a VL benchmark. Images are sent as OpenAI content parts (`image_url` base64 `data:` URIs, accepted by SGLang and vLLM). Everything else is orthogonal: text length comes from `--scenario` (or `--replay-dataset`), output from `--max-tokens`, and you sweep concurrency as usual — so latency/throughput vs concurrency plots via `plot-completion` unchanged.
+Attach images to every request with `--num-images` (and `--image-size`), turning any completion run into a VL benchmark. Images are sent as OpenAI content parts (`image_url` base64 `data:` URIs, accepted by SGLang and vLLM), and you sweep concurrency as usual — so latency/throughput vs concurrency via `plot-completion` is unchanged.
 
 ```bash
 tokenomics completion \
   --model your-vl-model \
-  --scenario "D(1024,32)" \
   --num-images 5 --image-size 512 \
   --max-concurrency 1,2,4,8,16 \
   --results-dir results/vl_512x5/
 ```
 
-- Synthetic images are plain white PNGs built on the fly (content doesn't affect VL speed), each stamped with its index so the server's multimodal cache can't dedupe them.
-- `--image-size` accepts `N` (square) or `WxH`.
-- Sweeping image size/count is external composition — loop the command over `--image-size`/`--num-images` values, one `--results-dir` each, then overlay with `plot-completion`.
+Image runs use short, deterministic defaults (the images dominate, the text is padding): a fixed filler prompt of `--input-tokens` (default 32), `--max-tokens` 32 output, and greedy decoding (temperature 0). Override any of them explicitly.
+
+- `--input-tokens` sets the filler length (`0` = images only); `--image-size` is `N` or `WxH`.
+- Synthetic images are white PNGs built on the fly (content doesn't affect VL speed). Every request gets a **unique** prompt id and **unique** images, so the server's prefix and multimodal caches can't dedupe them and undercount compute — while staying fully reproducible.
+- Sweep image size/count/text-length by looping the command (one `--results-dir` each) and overlaying with `plot-completion` — nothing is baked in.
+- Pass an explicit `--scenario` instead to drive the text from the dataset sampler (e.g. images on top of realistic prompts).
 
 ### Key Options
 
@@ -175,10 +177,12 @@ tokenomics completion \
 | `--max-concurrency` | Sustained mode sweep points |
 | `--num-prompts` | Prompts per sweep point in sustained mode |
 | `--num-runs` | Runs per sweep point (default: 3) |
-| `--max-tokens` | Max output tokens (default: 4096) |
+| `--max-tokens` | Max output tokens (default: 4096; 32 for image runs) |
 | `--ignore-eos` | Generate exactly `--max-tokens` per request, ignoring EOS (SGLang/vLLM). Fixes output length for clean cross-harness throughput comparison |
 | `--num-images` | Attach N synthetic (white) images to each request (0 = text-only, default) |
 | `--image-size` | Synthetic image size: `N` or `WxH` (default: 512; used when `--num-images` > 0) |
+| `--input-tokens` | Filler-text length for image runs without `--scenario` (default: 32; 0 = images only) |
+| `--temperature` | Sampling temperature (default: 0.7; 0.0 for image runs) |
 | `-n` | Completions per request (default: 1) |
 | `--stream` | Enable SSE streaming for TTFT/per-token metrics |
 | `--dataset-config` | Path to dataset config (default: bundled AIME) |

--- a/README.md
+++ b/README.md
@@ -21,51 +21,33 @@ uv pip install -e .
 
 ## Completion Benchmark
 
-Sends chat completion requests to any OpenAI-compatible server and records per-request and system-wide metrics.
+Sends chat completion requests to any OpenAI-compatible server and records per-request and system-wide metrics. Requests are non-streaming by default (max throughput); `--stream` adds TTFT and per-token metrics.
 
-By default, requests are non-streaming for maximum throughput. Use `--stream` to enable SSE streaming for TTFT and per-token latency metrics.
+Every run **sweeps concurrency** and writes one result JSON per sweep point. Two execution modes, mutually exclusive:
 
-### Usage
+- `--max-concurrency 1,2,4,…` — **sustained**: holds concurrency constant (realistic production numbers).
+- `--batch-sizes 1,2,4,…` — **burst**: fires each batch at once (peak throughput).
 
 ```bash
-# Sustained mode — maintains constant concurrency (recommended)
-tokenomics completion \
+tokenomics completion --model your-model \
   --scenario "D(1024,256)" \
-  --model your-model \
-  --max-concurrency 1,2,4,8,16,32,64,128,256,512,1024
-
-# Burst mode — fires all requests at once
-tokenomics completion \
-  --scenario "D(1024,256)" \
-  --model your-model \
-  --batch-sizes 1,2,4,8
-
-# Multiple completions per request (e.g. for RL rollouts)
-tokenomics completion \
-  --scenario "D(1024,256)" \
-  --model your-model \
-  --max-concurrency 1,2,4,8,16 \
-  -n 16
-
-# Streaming mode — enables TTFT and per-token metrics
-tokenomics completion \
-  --scenario "D(1024,256)" \
-  --model your-model \
-  --max-concurrency 1,2,4,8 \
-  --stream
-
-# Dataset-replay mode — walk a real dataset example by example (no --scenario)
-tokenomics completion \
-  --replay-dataset \
-  --dataset-config examples/dataset_configs/humaneval.json \
-  --model your-model \
-  --max-concurrency 1,2,4,8,16,32 \
-  --max-tokens 1024
+  --max-concurrency 1,2,4,8,16,32,64,128 \
+  --results-dir results/
 ```
 
-The two execution modes (`--batch-sizes` and `--max-concurrency`) are mutually exclusive. Burst is good for peak throughput; sustained gives realistic production numbers.
+### Building requests
 
-### Traffic Scenarios
+Three ways to produce request content, all swept over concurrency the same way:
+
+| Mode | Enable with | Text | Use for |
+|------|-------------|------|---------|
+| **Synthetic** | `--scenario` | random dataset snippets padded to a token budget | throughput curves at controlled input/output lengths |
+| **Dataset replay** | `--replay-dataset` | each dataset row, verbatim | real examples; comparing datasets |
+| **Images (VL)** | `--num-images` | fixed filler (or `--scenario`) + synthetic images | vision inference speed |
+
+#### Synthetic (`--scenario`)
+
+A scenario sets input/output token counts; the prompt is built by concatenating random dataset snippets (with replacement) until it reaches the input budget.
 
 | Pattern | Example | Description |
 |---------|---------|-------------|
@@ -73,62 +55,22 @@ The two execution modes (`--batch-sizes` and `--max-concurrency`) are mutually e
 | `N(mu,sigma)/(mu,sigma)` | `N(100,50)/(50,0)` | Normal distribution |
 | `U(min,max)/(min,max)` | `U(50,150)/(20,80)` | Uniform distribution |
 
-### Datasets
+The snippet source defaults to a bundled AIME dataset; override with `--dataset-config` (see [Dataset config](#dataset-config)).
 
-The benchmark uses a bundled AIME dataset by default. You can specify a custom dataset with `--dataset-config`.
+#### Dataset replay (`--replay-dataset`)
 
-The benchmark concatenates random text snippets from the dataset until it reaches the input token count specified by the scenario. Snippets are picked with replacement, so even a small dataset can produce long prompts.
-
-#### Dataset config format
-
-A dataset config is a JSON file with a `source` section:
-
-**Local file** (TXT, CSV, or JSON):
-```json
-{
-  "source": { "type": "file", "path": "../data/prompts.txt" },
-  "prompt_column": "text"
-}
-```
-File paths are resolved relative to the config file.
-
-**HuggingFace dataset:**
-```json
-{
-  "source": {
-    "type": "huggingface",
-    "path": "squad",
-    "huggingface_kwargs": { "split": "train" }
-  },
-  "prompt_column": "question"
-}
-```
-
-**AIME** (built-in shortcut):
-```json
-{
-  "source": { "type": "aime" }
-}
-```
-
-See `examples/dataset_configs/` for more examples.
-
-### Dataset Replay Mode
-
-`--replay-dataset` sends each dataset row **verbatim as one request** and walks the dataset in order at each concurrency level, instead of synthesizing prompts to the scenario's token budget. Use it to benchmark on real examples and compare datasets. The prompt set is pinned (same rows, same order across every concurrency and run), so results line up example by example.
+Sends each dataset row **verbatim as one request** and walks the dataset in order, instead of synthesizing prompts. The prompt set is pinned (same rows, same order across every concurrency level and run), so results line up example by example.
 
 ```bash
-tokenomics completion \
-  --replay-dataset \
-  --dataset-config examples/dataset_configs/humaneval.json \
-  --model your-model \
+tokenomics completion --model your-model \
+  --replay-dataset --dataset-config examples/dataset_configs/humaneval.json \
   --max-concurrency 1,2,4,8,16,32 --max-tokens 1024 \
   --results-dir results/humaneval/
 ```
 
-- Sustained mode only (`--max-concurrency`); `--scenario` is ignored.
+- Sustained mode only; `--scenario` is ignored.
 - `--num-prompts N` caps the walk to the first N rows (default: whole dataset).
-- List prompt columns (MT-Bench `prompt`, Arena-Hard `turns`) are reduced to the first turn's string — MT-Bench runs single-turn.
+- List prompt columns (MT-Bench `prompt`, Arena-Hard `turns`) are reduced to the first turn — MT-Bench runs single-turn.
 
 Bundled configs under `examples/dataset_configs/`:
 
@@ -144,48 +86,63 @@ Bundled configs under `examples/dataset_configs/`:
 | `alpaca.json` | `tatsu-lab/alpaca_eval` (eval) | instruction following (AlpacaEval) |
 | `arena_hard.json` | `lmarena-ai/arena-hard-auto-v0.1` (train) | hard instruction following (Arena-Hard) |
 
-**`--ignore-eos`** makes every request generate exactly `--max-tokens` (EOS ignored), fixing output length so throughput isn't skewed by content-dependent token counts. Add it when comparing harnesses, servers, or configs; omit it for realistic, content-driven lengths. Supported by SGLang and vLLM — servers that don't implement it ignore the field, so it silently has no effect there.
+#### Images (`--num-images`)
 
-### Vision / multimodal
-
-Attach images to every request with `--num-images` (and `--image-size`), turning any completion run into a VL benchmark. Images are sent as OpenAI content parts (`image_url` base64 `data:` URIs, accepted by SGLang and vLLM), and you sweep concurrency as usual — so latency/throughput vs concurrency via `plot-completion` is unchanged.
+Attach images to any run — sent as OpenAI content parts (`image_url` base64 `data:` URIs, accepted by SGLang and vLLM) — turning it into a VL benchmark. Metrics and plotting are unchanged.
 
 ```bash
-tokenomics completion \
-  --model your-vl-model \
+tokenomics completion --model your-vl-model \
   --num-images 5 --image-size 512x512 \
   --max-concurrency 1,2,4,8,16 \
   --results-dir results/vl_512x5/
 ```
 
-Image runs default to a short workload (the images dominate, the text is padding): a fixed filler prompt of `--input-tokens` (default 32) and `--max-tokens` 32 output. Override either explicitly, and add `--temperature 0` / `--ignore-eos` if you want fully reproducible generation.
+Image runs default to a short workload (the images dominate, the text is padding): a fixed filler of `--input-tokens` (default 32) and `--max-tokens` 32 output.
 
-- `--input-tokens` sets the filler length (`0` = images only). `--image-size` is `N` for a square or `WxH` for a rectangle — e.g. `--image-size 512` (512×512) or `--image-size 1024x768` (width × height, lowercase `x`, no spaces).
-- Synthetic images are random-noise PNGs built on the fly, seeded per request so they're **unique** (defeating the server's prefix/multimodal caches) yet reproducible. Note noise is nearly incompressible (~MBs at 1024×1024), so keep image size/count sane or the payload dominates.
-- Sweep image size/count/text-length by looping the command (one `--results-dir` each) and overlaying with `plot-completion` — nothing is baked in.
-- `--input-tokens` and `--scenario` are mutually exclusive (both set text length) — pass `--scenario` instead to drive the text from the dataset sampler (e.g. images on top of realistic prompts).
+- `--image-size` is `N` (square) or `WxH` (e.g. `1024x768`, lowercase `x`); `--input-tokens 0` = images only.
+- Synthetic images are random-noise PNGs, seeded per request → **unique** (defeats the server's prefix/multimodal caches) yet reproducible. Noise is nearly incompressible (~MBs at 1024×1024), so keep size/count modest or the payload dominates.
+- `--input-tokens` and `--scenario` are mutually exclusive; pass `--scenario` to put images on dataset-driven text instead.
+- Sweep size/count/length by looping the command (one `--results-dir` each) and overlaying with `plot-completion`.
+
+### Dataset config
+
+A JSON file with a `source` and (usually) a `prompt_column`. File paths are resolved relative to the config file.
+
+```json
+{ "source": { "type": "huggingface", "path": "openai/gsm8k",
+              "huggingface_kwargs": { "name": "main", "split": "test" } },
+  "prompt_column": "question" }
+```
+
+`source.type` is `huggingface`, `file` (`.txt`/`.csv`/`.json`), or `aime` (bundled shortcut). See `examples/dataset_configs/` for more.
+
+### Output length & reproducibility
+
+`--ignore-eos` makes every request generate exactly `--max-tokens` (EOS ignored), fixing output length so throughput isn't skewed by content-dependent token counts. Add it when comparing harnesses, servers, or configs; omit it for realistic, content-driven lengths. Supported by SGLang and vLLM — a no-op on servers that ignore the field.
+
+`--max-tokens` defaults to 4096 (32 for image runs) and `--temperature` to 0.7. For fully reproducible runs, use `--temperature 0` with `--ignore-eos`.
 
 ### Key Options
 
 | Flag | Description |
 |------|-------------|
-| `--scenario` | Traffic pattern (required unless `--replay-dataset`) |
-| `--replay-dataset` | Send each dataset row verbatim and walk the dataset at each concurrency level (ignores `--scenario`; sustained mode only) |
 | `--model` | Model name (required) |
+| `--scenario` | Traffic pattern (required unless `--replay-dataset` or `--num-images`) |
 | `--api-base` | Server URL (default: `http://localhost:8000/v1`) |
-| `--batch-sizes` | Burst mode sweep points |
 | `--max-concurrency` | Sustained mode sweep points |
+| `--batch-sizes` | Burst mode sweep points |
 | `--num-prompts` | Prompts per sweep point in sustained mode |
 | `--num-runs` | Runs per sweep point (default: 3) |
 | `--max-tokens` | Max output tokens (default: 4096; 32 for image runs) |
-| `--ignore-eos` | Generate exactly `--max-tokens` per request, ignoring EOS (SGLang/vLLM). Fixes output length for clean cross-harness throughput comparison |
-| `--num-images` | Attach N synthetic (random-noise) images to each request (0 = text-only, default) |
-| `--image-size` | Synthetic image size: `N` or `WxH` (default: 512; used when `--num-images` > 0) |
-| `--input-tokens` | Filler-text length for image runs without `--scenario` (default: 32; 0 = images only) |
 | `--temperature` | Sampling temperature (default: 0.7) |
-| `-n` | Completions per request (default: 1) |
+| `--ignore-eos` | Generate exactly `--max-tokens`, ignoring EOS (SGLang/vLLM) — fixes output length for clean comparisons |
 | `--stream` | Enable SSE streaming for TTFT/per-token metrics |
+| `-n` | Completions per request (default: 1) |
 | `--dataset-config` | Path to dataset config (default: bundled AIME) |
+| `--replay-dataset` | Send each dataset row verbatim (sustained only; ignores `--scenario`) |
+| `--num-images` | Attach N synthetic random-noise images per request (0 = text-only) |
+| `--image-size` | Synthetic image size: `N` or `WxH` (default: 512) |
+| `--input-tokens` | Filler-text length for image runs (default: 32; 0 = images only) |
 | `--results-dir` | Output directory (one JSON per sweep value) |
 | `--lora-strategy` | LoRA distribution: single, uniform, zipf, mixed, all-unique |
 | `--lora-names` | Comma-separated LoRA adapter names |
@@ -205,7 +162,7 @@ Image runs default to a short workload (the images dominate, the text is padding
 ### Plotting
 
 ```bash
-# Compare multiple benchmarks
+# Compare multiple benchmarks (overlays each results dir as its own line)
 tokenomics plot-completion output.png results_dir1/ results_dir2/
 ```
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,23 @@ Bundled configs under `examples/dataset_configs/`:
 
 **`--ignore-eos`** makes every request generate exactly `--max-tokens` (EOS ignored), fixing output length so throughput isn't skewed by content-dependent token counts. Add it when comparing harnesses, servers, or configs; omit it for realistic, content-driven lengths. Supported by SGLang and vLLM — servers that don't implement it ignore the field, so it silently has no effect there.
 
+### Vision / multimodal
+
+Attach images to every request with `--num-images` and `--image-size`, turning any completion run into a VL benchmark. Images are sent as OpenAI content parts (`image_url` base64 `data:` URIs, accepted by SGLang and vLLM). Everything else is orthogonal: text length comes from `--scenario` (or `--replay-dataset`), output from `--max-tokens`, and you sweep concurrency as usual — so latency/throughput vs concurrency plots via `plot-completion` unchanged.
+
+```bash
+tokenomics completion \
+  --model your-vl-model \
+  --scenario "D(1024,32)" \
+  --num-images 5 --image-size 512 \
+  --max-concurrency 1,2,4,8,16 \
+  --results-dir results/vl_512x5/
+```
+
+- Synthetic images are plain white PNGs built on the fly (content doesn't affect VL speed), each stamped with its index so the server's multimodal cache can't dedupe them.
+- `--image-size` accepts `N` (square) or `WxH`.
+- Sweeping image size/count is external composition — loop the command over `--image-size`/`--num-images` values, one `--results-dir` each, then overlay with `plot-completion`.
+
 ### Key Options
 
 | Flag | Description |
@@ -160,6 +177,8 @@ Bundled configs under `examples/dataset_configs/`:
 | `--num-runs` | Runs per sweep point (default: 3) |
 | `--max-tokens` | Max output tokens (default: 4096) |
 | `--ignore-eos` | Generate exactly `--max-tokens` per request, ignoring EOS (SGLang/vLLM). Fixes output length for clean cross-harness throughput comparison |
+| `--num-images` | Attach N synthetic (white) images to each request (0 = text-only, default) |
+| `--image-size` | Synthetic image size: `N` or `WxH` (default: 512; used when `--num-images` > 0) |
 | `-n` | Completions per request (default: 1) |
 | `--stream` | Enable SSE streaming for TTFT/per-token metrics |
 | `--dataset-config` | Path to dataset config (default: bundled AIME) |

--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ Bundled configs under `examples/dataset_configs/`:
 | `alpaca.json` | `tatsu-lab/alpaca_eval` (eval) | instruction following (AlpacaEval) |
 | `arena_hard.json` | `lmarena-ai/arena-hard-auto-v0.1` (train) | hard instruction following (Arena-Hard) |
 
+**Vision replay:** a config with an `image_column` (in addition to `prompt_column`) replays real image+text examples — each row's image(s) are attached to the request. This is the realistic VL workload (real prompts + real images, generating to natural EOS), e.g. for speculative-decoding evaluation. Bundled vision configs:
+
+| Config | Dataset | Domain |
+|--------|---------|--------|
+| `chartqa.json` | `lmms-lab/ChartQA` (test) | chart question answering |
+| `vqa_rad.json` | `flaviagiammarino/vqa-rad` (test) | radiology visual QA |
+| `docvqa.json` | `lmms-lab/DocVQA` (validation) | document-image QA |
+
+```bash
+tokenomics completion --model your-vl-model \
+  --replay-dataset --dataset-config examples/dataset_configs/chartqa.json \
+  --max-concurrency 1,2,4,8,16 --results-dir results/chartqa/
+```
+
 #### Images (`--num-images`)
 
 Attach images to any run — sent as OpenAI content parts (`image_url` base64 `data:` URIs, accepted by SGLang and vLLM) — turning it into a VL benchmark. Metrics and plotting are unchanged.
@@ -114,7 +128,7 @@ A JSON file with a `source` and (usually) a `prompt_column`. File paths are reso
   "prompt_column": "question" }
 ```
 
-`source.type` is `huggingface`, `file` (`.txt`/`.csv`/`.json`), or `aime` (bundled shortcut). See `examples/dataset_configs/` for more.
+`source.type` is `huggingface`, `file` (`.txt`/`.csv`/`.json`), or `aime` (bundled shortcut). Add an `image_column` (alongside `prompt_column`) to replay a vision dataset — its images (embedded PIL, `{bytes/path}`, or file paths) are encoded and attached per request. See `examples/dataset_configs/` for more.
 
 ### Output length & reproducibility
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ tokenomics completion \
   --results-dir results/vl_512x5/
 ```
 
-Image runs use short, deterministic defaults (the images dominate, the text is padding): a fixed filler prompt of `--input-tokens` (default 32), `--max-tokens` 32 output, and greedy decoding (temperature 0). Override any of them explicitly.
+Image runs default to a short workload (the images dominate, the text is padding): a fixed filler prompt of `--input-tokens` (default 32) and `--max-tokens` 32 output. Override either explicitly, and add `--temperature 0` / `--ignore-eos` if you want fully reproducible generation.
 
 - `--input-tokens` sets the filler length (`0` = images only). `--image-size` is `N` for a square or `WxH` for a rectangle — e.g. `--image-size 512` (512×512) or `--image-size 1024x768` (width × height, lowercase `x`, no spaces).
 - Synthetic images are random-noise PNGs built on the fly, seeded per request so they're **unique** (defeating the server's prefix/multimodal caches) yet reproducible. Note noise is nearly incompressible (~MBs at 1024×1024), so keep image size/count sane or the payload dominates.
@@ -182,7 +182,7 @@ Image runs use short, deterministic defaults (the images dominate, the text is p
 | `--num-images` | Attach N synthetic (random-noise) images to each request (0 = text-only, default) |
 | `--image-size` | Synthetic image size: `N` or `WxH` (default: 512; used when `--num-images` > 0) |
 | `--input-tokens` | Filler-text length for image runs without `--scenario` (default: 32; 0 = images only) |
-| `--temperature` | Sampling temperature (default: 0.7; 0.0 for image runs) |
+| `--temperature` | Sampling temperature (default: 0.7) |
 | `-n` | Completions per request (default: 1) |
 | `--stream` | Enable SSE streaming for TTFT/per-token metrics |
 | `--dataset-config` | Path to dataset config (default: bundled AIME) |

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Attach images to every request with `--num-images` (and `--image-size`), turning
 ```bash
 tokenomics completion \
   --model your-vl-model \
-  --num-images 5 --image-size 512 \
+  --num-images 5 --image-size 512x512 \
   --max-concurrency 1,2,4,8,16 \
   --results-dir results/vl_512x5/
 ```

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ tokenomics completion \
 
 Image runs use short, deterministic defaults (the images dominate, the text is padding): a fixed filler prompt of `--input-tokens` (default 32), `--max-tokens` 32 output, and greedy decoding (temperature 0). Override any of them explicitly.
 
-- `--input-tokens` sets the filler length (`0` = images only); `--image-size` is `N` or `WxH`.
+- `--input-tokens` sets the filler length (`0` = images only). `--image-size` is `N` for a square or `WxH` for a rectangle — e.g. `--image-size 512` (512×512) or `--image-size 1024x768` (width × height, lowercase `x`, no spaces).
 - Synthetic images are random-noise PNGs built on the fly, seeded per request so they're **unique** (defeating the server's prefix/multimodal caches) yet reproducible. Note noise is nearly incompressible (~MBs at 1024×1024), so keep image size/count sane or the payload dominates.
 - Sweep image size/count/text-length by looping the command (one `--results-dir` each) and overlaying with `plot-completion` — nothing is baked in.
 - Pass an explicit `--scenario` instead to drive the text from the dataset sampler (e.g. images on top of realistic prompts).

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ tokenomics completion \
 Image runs use short, deterministic defaults (the images dominate, the text is padding): a fixed filler prompt of `--input-tokens` (default 32), `--max-tokens` 32 output, and greedy decoding (temperature 0). Override any of them explicitly.
 
 - `--input-tokens` sets the filler length (`0` = images only); `--image-size` is `N` or `WxH`.
-- Synthetic images are white PNGs built on the fly (content doesn't affect VL speed). Every request gets a **unique** prompt id and **unique** images, so the server's prefix and multimodal caches can't dedupe them and undercount compute — while staying fully reproducible.
+- Synthetic images are random-noise PNGs built on the fly, seeded per request so they're **unique** (defeating the server's prefix/multimodal caches) yet reproducible. Note noise is nearly incompressible (~MBs at 1024×1024), so keep image size/count sane or the payload dominates.
 - Sweep image size/count/text-length by looping the command (one `--results-dir` each) and overlaying with `plot-completion` — nothing is baked in.
 - Pass an explicit `--scenario` instead to drive the text from the dataset sampler (e.g. images on top of realistic prompts).
 
@@ -179,7 +179,7 @@ Image runs use short, deterministic defaults (the images dominate, the text is p
 | `--num-runs` | Runs per sweep point (default: 3) |
 | `--max-tokens` | Max output tokens (default: 4096; 32 for image runs) |
 | `--ignore-eos` | Generate exactly `--max-tokens` per request, ignoring EOS (SGLang/vLLM). Fixes output length for clean cross-harness throughput comparison |
-| `--num-images` | Attach N synthetic (white) images to each request (0 = text-only, default) |
+| `--num-images` | Attach N synthetic (random-noise) images to each request (0 = text-only, default) |
 | `--image-size` | Synthetic image size: `N` or `WxH` (default: 512; used when `--num-images` > 0) |
 | `--input-tokens` | Filler-text length for image runs without `--scenario` (default: 32; 0 = images only) |
 | `--temperature` | Sampling temperature (default: 0.7; 0.0 for image runs) |

--- a/examples/dataset_configs/chartqa.json
+++ b/examples/dataset_configs/chartqa.json
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "type": "huggingface",
+    "path": "lmms-lab/ChartQA",
+    "huggingface_kwargs": { "split": "test" }
+  },
+  "prompt_column": "question",
+  "image_column": "image",
+  "description": "ChartQA (chart question answering), one chart image + question per row. Vision replay: use with --replay-dataset."
+}

--- a/examples/dataset_configs/docvqa.json
+++ b/examples/dataset_configs/docvqa.json
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "type": "huggingface",
+    "path": "lmms-lab/DocVQA",
+    "huggingface_kwargs": { "name": "DocVQA", "split": "validation" }
+  },
+  "prompt_column": "question",
+  "image_column": "image",
+  "description": "DocVQA (document-image visual QA), one document image + question per row. Vision replay: use with --replay-dataset."
+}

--- a/examples/dataset_configs/vqa_rad.json
+++ b/examples/dataset_configs/vqa_rad.json
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "type": "huggingface",
+    "path": "flaviagiammarino/vqa-rad",
+    "huggingface_kwargs": { "split": "test" }
+  },
+  "prompt_column": "question",
+  "image_column": "image",
+  "description": "VQA-RAD (radiology visual QA, 451 rows), one image + question per row. Vision replay: use with --replay-dataset."
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "aiohttp",
     "numpy",
     "tokenizers",
+    "pillow",
 ]
 
 [project.urls]

--- a/tokenomics/completion_benchmark.py
+++ b/tokenomics/completion_benchmark.py
@@ -23,50 +23,8 @@ NS_PER_SECOND = 1_000_000_000
 os.environ["HF_DATASETS_DISABLE_PROGRESS_BARS"] = "1"
 os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
 
-from .sampling import Scenario, TextSampler, DatasetReplaySampler, FixedFillerSampler, DatasetConfig, DatasetLoader, use_seed, derive_seed
+from .sampling import Scenario, TextSampler, DatasetReplaySampler, FixedFillerSampler, DatasetConfig, DatasetLoader, use_seed, derive_seed, build_synthetic_image_uris
 from .io import round_floats, atomic_write_json
-
-
-def _parse_image_size(spec: str) -> tuple:
-    """Parse an image size spec: '512' -> (512, 512), '640x480' -> (640, 480)."""
-    parts = str(spec).lower().split("x")
-    if len(parts) == 1:
-        w = h = int(parts[0])
-    elif len(parts) == 2:
-        w, h = int(parts[0]), int(parts[1])
-    else:
-        raise ValueError(f"Invalid --image-size '{spec}'; use N or WxH")
-    return w, h
-
-
-def build_synthetic_image_uris(size: str, count: int, start_id: int = 0) -> List[str]:
-    """Return `count` random-noise PNG images (as base64 ``data:`` URIs).
-
-    Each image is filled with random pixels seeded by a unique id (``start_id +
-    k``), so it is deterministic (reproducible across runs) yet unique across the
-    whole benchmark — which keeps the server's prefix and multimodal caches from
-    deduplicating requests and undercounting vision-encoder compute. Pixel
-    *content* doesn't change VL compute (patch count is fixed by size), but note
-    noise is nearly incompressible, so payloads are much larger than a flat
-    image (~MBs at 1024x1024) — keep image size/count sane for the transport.
-    """
-    if count <= 0:
-        return []
-    import base64
-    import io as _io
-    import numpy as np
-    from PIL import Image
-
-    w, h = _parse_image_size(size)
-    uris = []
-    for k in range(count):
-        rng = np.random.default_rng(start_id + k)  # deterministic, unique per image
-        arr = rng.integers(0, 256, size=(h, w, 3), dtype=np.uint8)
-        buf = _io.BytesIO()
-        Image.fromarray(arr, "RGB").save(buf, format="PNG")
-        b64 = base64.b64encode(buf.getvalue()).decode("ascii")
-        uris.append(f"data:image/png;base64,{b64}")
-    return uris
 
 
 def _safe_mean(values):
@@ -886,7 +844,7 @@ def main():
                         help="Total prompts per sweep point in sustained mode (default: max(64, 8*concurrency))")
     parser.add_argument("--num-runs", type=int, default=3, help="Number of runs per sweep point")
     parser.add_argument("--warmup-runs", type=int, default=3, help="Number of warmup runs before each sweep point")
-    parser.add_argument("--temperature", type=float, default=None, help="Temperature (default: 0.7, or 0.0 for image runs)")
+    parser.add_argument("--temperature", type=float, default=0.7, help="Sampling temperature (default: 0.7)")
     parser.add_argument("--max-tokens", type=int, default=None, help="Upper bound on max_tokens per request (default: 4096, or 32 for image runs)")
     parser.add_argument("--ignore-eos", action="store_true", help="Ignore EOS and generate exactly max_tokens per request (SGLang/vLLM; a no-op on servers that don't support it). Fixes output length for clean throughput comparison.")
     parser.add_argument("-n", "--num-completions", type=int, default=1, help="Number of completions per request (default: 1)")
@@ -933,13 +891,11 @@ def main():
     elif args.scenario is None and args.num_images == 0:
         parser.error("--scenario is required unless --replay-dataset or --num-images is set")
 
-    # Image runs default to short, deterministic settings (the text is just
-    # padding and the images dominate): a fixed filler prompt of --input-tokens,
-    # 32 output tokens, and greedy decoding. Text-only runs keep their defaults.
+    # Image runs default to short output (the text is just padding and the
+    # images dominate): 32 tokens vs 4096 for text-only. Temperature is not
+    # mode-dependent — pass --temperature 0 / --ignore-eos for reproducibility.
     if args.max_tokens is None:
         args.max_tokens = 32 if args.num_images > 0 else 4096
-    if args.temperature is None:
-        args.temperature = 0.0 if args.num_images > 0 else 0.7
 
     # Create LoRA config from command-line arguments
     lora_config = None

--- a/tokenomics/completion_benchmark.py
+++ b/tokenomics/completion_benchmark.py
@@ -23,7 +23,7 @@ NS_PER_SECOND = 1_000_000_000
 os.environ["HF_DATASETS_DISABLE_PROGRESS_BARS"] = "1"
 os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
 
-from .sampling import Scenario, TextSampler, DatasetReplaySampler, DatasetConfig, DatasetLoader, use_seed, derive_seed
+from .sampling import Scenario, TextSampler, DatasetReplaySampler, FixedFillerSampler, DatasetConfig, DatasetLoader, use_seed, derive_seed
 from .io import round_floats, atomic_write_json
 
 
@@ -39,13 +39,15 @@ def _parse_image_size(spec: str) -> tuple:
     return w, h
 
 
-def build_synthetic_image_uris(size: str, count: int) -> List[str]:
+def build_synthetic_image_uris(size: str, count: int, start_id: int = 0) -> List[str]:
     """Return `count` white PNG images (as base64 ``data:`` URIs) of the given size.
 
-    Each image is stamped with its index (one pixel) so they hash differently,
-    preventing the server's multimodal cache from deduplicating them and
-    undercounting prefill compute. Image *content* is otherwise irrelevant to
-    VL model speed, so all-white is fine.
+    Each image is stamped with a unique 32-bit id (``start_id + k``, across four
+    pixels) so every image hashes differently — preventing the server's
+    multimodal cache from deduplicating identical images and undercounting the
+    vision-encoder compute. Callers pass a per-request ``start_id`` so images are
+    unique across the whole benchmark, not just within one request. Image
+    *content* is otherwise irrelevant to VL model speed, so all-white is fine.
     """
     if count <= 0:
         return []
@@ -55,10 +57,12 @@ def build_synthetic_image_uris(size: str, count: int) -> List[str]:
 
     w, h = _parse_image_size(size)
     uris = []
-    for i in range(count):
+    for k in range(count):
+        uid = start_id + k
         img = Image.new("RGB", (w, h), (255, 255, 255))
-        # Stamp the index into the top-left pixel to make each image unique.
-        img.putpixel((0, 0), (i % 256, (i // 256) % 256, 254))
+        for px in range(4):  # encode uid over 4 pixels -> 2^32 distinct images
+            b = (uid >> (8 * px)) & 0xFF
+            img.putpixel((px, 0), (b, b, b))
         buf = _io.BytesIO()
         img.save(buf, format="PNG")
         b64 = base64.b64encode(buf.getvalue()).decode("ascii")
@@ -883,14 +887,15 @@ def main():
                         help="Total prompts per sweep point in sustained mode (default: max(64, 8*concurrency))")
     parser.add_argument("--num-runs", type=int, default=3, help="Number of runs per sweep point")
     parser.add_argument("--warmup-runs", type=int, default=3, help="Number of warmup runs before each sweep point")
-    parser.add_argument("--temperature", type=float, default=0.7, help="Temperature parameter")
-    parser.add_argument("--max-tokens", type=int, default=4096, help="Upper bound on max_tokens per request (default: 4096)")
+    parser.add_argument("--temperature", type=float, default=None, help="Temperature (default: 0.7, or 0.0 for image runs)")
+    parser.add_argument("--max-tokens", type=int, default=None, help="Upper bound on max_tokens per request (default: 4096, or 32 for image runs)")
     parser.add_argument("--ignore-eos", action="store_true", help="Ignore EOS and generate exactly max_tokens per request (SGLang/vLLM; a no-op on servers that don't support it). Fixes output length for clean throughput comparison.")
     parser.add_argument("-n", "--num-completions", type=int, default=1, help="Number of completions per request (default: 1)")
 
     # Vision/multimodal: attach synthetic white images to every request
     parser.add_argument("--num-images", type=int, default=0, help="Attach this many synthetic (white) images to each request. 0 = text-only (default).")
     parser.add_argument("--image-size", type=str, default="512", help="Synthetic image size as N (square) or WxH, e.g. 512 or 1024x768 (default: 512). Only used when --num-images > 0.")
+    parser.add_argument("--input-tokens", type=int, default=32, help="Length of the deterministic filler text for image runs when --scenario is not given (default: 32; 0 = images only).")
     parser.add_argument("--stream", action="store_true", help="Enable streaming (for TTFT/per-token metrics, lower throughput)")
     parser.add_argument("--description", default="Benchmark", help="Description of the benchmark")
     
@@ -926,8 +931,16 @@ def main():
     if args.replay_dataset:
         if execution_mode != "sustained":
             parser.error("--replay-dataset requires --max-concurrency (sustained mode)")
-    elif args.scenario is None:
-        parser.error("--scenario is required unless --replay-dataset is set")
+    elif args.scenario is None and args.num_images == 0:
+        parser.error("--scenario is required unless --replay-dataset or --num-images is set")
+
+    # Image runs default to short, deterministic settings (the text is just
+    # padding and the images dominate): a fixed filler prompt of --input-tokens,
+    # 32 output tokens, and greedy decoding. Text-only runs keep their defaults.
+    if args.max_tokens is None:
+        args.max_tokens = 32 if args.num_images > 0 else 4096
+    if args.temperature is None:
+        args.temperature = 0.0 if args.num_images > 0 else 0.7
 
     # Create LoRA config from command-line arguments
     lora_config = None
@@ -941,18 +954,27 @@ def main():
         )
         print(f"🔧 LoRA config: strategy={lora_config.strategy}, {len(lora_config.lora_names)} LoRAs, base_model_ratio={lora_config.base_model_ratio}")
 
+    # Image runs with no explicit --scenario use a deterministic fixed filler
+    # (no dataset needed); a given --scenario still routes through TextSampler.
+    use_filler = args.num_images > 0 and args.scenario is None and not args.replay_dataset
+
     # Initialize scenario and dataset
-    scenario = None if args.replay_dataset else Scenario.from_string(args.scenario)
-    if args.dataset_config is None:
-        from tokenomics import EXAMPLES_DIR
-        args.dataset_config = str(EXAMPLES_DIR / "dataset_configs" / "aime_simple.json")
-    dataset_config = DatasetConfig.from_file(args.dataset_config)
-    dataset_loader = DatasetLoader(dataset_config)
+    scenario = None if (args.replay_dataset or use_filler) else Scenario.from_string(args.scenario)
+    dataset_config = None
+    dataset_loader = None
+    if not use_filler:
+        if args.dataset_config is None:
+            from tokenomics import EXAMPLES_DIR
+            args.dataset_config = str(EXAMPLES_DIR / "dataset_configs" / "aime_simple.json")
+        dataset_config = DatasetConfig.from_file(args.dataset_config)
+        dataset_loader = DatasetLoader(dataset_config)
 
     tokenizer_name = args.tokenizer or args.model
 
     if args.replay_dataset:
         text_sampler = DatasetReplaySampler(tokenizer_name, dataset_loader, args.max_tokens)
+    elif use_filler:
+        text_sampler = FixedFillerSampler(tokenizer_name, args.input_tokens, args.max_tokens)
     else:
         text_sampler = TextSampler(tokenizer_name, dataset_loader)
 
@@ -965,16 +987,17 @@ def main():
         except Exception:
             return int(len(text.split()) * 1.3)
 
-    # Synthetic images (built once; content-independent, so shared by every request)
-    image_uris = build_synthetic_image_uris(args.image_size, args.num_images)
-    if image_uris:
-        print(f"🖼️  Attaching {args.num_images} synthetic image(s) of size {args.image_size} to each request")
+    if args.num_images > 0:
+        print(f"🖼️  Attaching {args.num_images} synthetic image(s) of size {args.image_size} to each request (unique per request)")
 
     if args.replay_dataset:
         print(f"📊 Initialized benchmark in dataset-replay mode (max_tokens={args.max_tokens})")
+    elif use_filler:
+        print(f"📊 Initialized benchmark with fixed filler ({args.input_tokens} input tokens, max_tokens={args.max_tokens}, temperature={args.temperature})")
     else:
         print(f"📊 Initialized benchmark with scenario: {args.scenario}")
-    print(f"📚 Loaded dataset: {len(dataset_loader)} samples")
+    if dataset_loader is not None:
+        print(f"📚 Loaded dataset: {len(dataset_loader)} samples")
     print(f"⚙️  Execution mode: {execution_mode}")
     if lora_config:
         print(f"🎯 LoRA strategy: {lora_config.strategy} with {len(lora_config.lora_names)} adapters")
@@ -985,11 +1008,12 @@ def main():
         "timestamp": datetime.now().isoformat(),
         "model": args.model,
         "scenario": args.scenario,
-        "prompt_source": "dataset_replay" if args.replay_dataset else "scenario",
+        "prompt_source": "dataset_replay" if args.replay_dataset else ("fixed_filler" if use_filler else "scenario"),
         "max_tokens": args.max_tokens,
         "num_images": args.num_images,
         "image_size": args.image_size if args.num_images > 0 else None,
-        "dataset_config": dataset_config.config,
+        "input_tokens": args.input_tokens if use_filler else None,
+        "dataset_config": dataset_config.config if dataset_config is not None else None,
         "api_base": args.api_base,
         "execution_mode": execution_mode,
         "num_runs": args.num_runs,
@@ -1017,6 +1041,11 @@ def main():
     # Create results directory
     os.makedirs(args.results_dir, exist_ok=True)
 
+    # Monotonic per-request id (image runs only), so every request across the
+    # whole benchmark gets a unique prompt prefix + unique images -> defeats the
+    # server's prefix and multimodal caches. Deterministic (fixed iteration order).
+    req_uid = 0
+
     # Run benchmark for each sweep value
     for sweep_value in sweep_values:
         if execution_mode == "sustained":
@@ -1033,11 +1062,14 @@ def main():
             max_concurrency = None
             print(f"\n🔄 Testing batch size: {sweep_value}")
 
+        # Warmup images use a disjoint id range so they don't cache-collide with
+        # the measured requests (whose ids start at 0).
+        warmup_images = build_synthetic_image_uris(args.image_size, args.num_images, start_id=2**31) if args.num_images > 0 else None
         warmup_seed = derive_seed(args.seed, sweep_value, -1)
         with use_seed(warmup_seed):
             warmup_server(args.api_base, args.model, args.temperature, args.timeout,
                          text_sampler, args.warmup_runs, api_key=args.api_key,
-                         image_uris=image_uris)
+                         image_uris=warmup_images)
 
         runs_data = []
         for run_idx in range(args.num_runs):
@@ -1065,8 +1097,16 @@ def main():
                     request_dict["lora_name"] = lora_assignments[idx]
                 if args.ignore_eos:
                     request_dict["ignore_eos"] = True
-                if image_uris:
-                    request_dict["images"] = image_uris
+                if args.num_images > 0:
+                    uid = req_uid
+                    req_uid += 1
+                    # Unique text prefix + unique images so each request is a
+                    # cache miss (prefix + multimodal caches), while staying
+                    # deterministic (uid is derived from fixed iteration order).
+                    base = request_dict["prompt"]
+                    request_dict["prompt"] = f"{uid} {base}" if base else str(uid)
+                    request_dict["images"] = build_synthetic_image_uris(
+                        args.image_size, args.num_images, start_id=uid * args.num_images)
                 user_requests.append(request_dict)
 
             run_data = run_benchmark_batch(

--- a/tokenomics/completion_benchmark.py
+++ b/tokenomics/completion_benchmark.py
@@ -23,7 +23,7 @@ NS_PER_SECOND = 1_000_000_000
 os.environ["HF_DATASETS_DISABLE_PROGRESS_BARS"] = "1"
 os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
 
-from .sampling import Scenario, TextSampler, DatasetReplaySampler, FixedFillerSampler, DatasetConfig, DatasetLoader, use_seed, derive_seed, build_synthetic_image_uris
+from .sampling import Scenario, TextSampler, DatasetReplaySampler, FixedFillerSampler, DatasetConfig, DatasetLoader, use_seed, derive_seed, build_synthetic_image_uris, count_tokens
 from .io import round_floats, atomic_write_json
 
 
@@ -946,12 +946,7 @@ def main():
 
     def count_output_tokens(text: str) -> int:
         """Client-side output-token count used when the server omits usage."""
-        if not text:
-            return 0
-        try:
-            return len(text_sampler.tokenizer.encode(text).ids)
-        except Exception:
-            return int(len(text.split()) * 1.3)
+        return count_tokens(text_sampler.tokenizer, text) if text else 0
 
     if args.num_images > 0:
         print(f"🖼️  Attaching {args.num_images} synthetic image(s) of size {args.image_size} to each request (unique per request)")

--- a/tokenomics/completion_benchmark.py
+++ b/tokenomics/completion_benchmark.py
@@ -27,6 +27,45 @@ from .sampling import Scenario, TextSampler, DatasetReplaySampler, DatasetConfig
 from .io import round_floats, atomic_write_json
 
 
+def _parse_image_size(spec: str) -> tuple:
+    """Parse an image size spec: '512' -> (512, 512), '640x480' -> (640, 480)."""
+    parts = str(spec).lower().split("x")
+    if len(parts) == 1:
+        w = h = int(parts[0])
+    elif len(parts) == 2:
+        w, h = int(parts[0]), int(parts[1])
+    else:
+        raise ValueError(f"Invalid --image-size '{spec}'; use N or WxH")
+    return w, h
+
+
+def build_synthetic_image_uris(size: str, count: int) -> List[str]:
+    """Return `count` white PNG images (as base64 ``data:`` URIs) of the given size.
+
+    Each image is stamped with its index (one pixel) so they hash differently,
+    preventing the server's multimodal cache from deduplicating them and
+    undercounting prefill compute. Image *content* is otherwise irrelevant to
+    VL model speed, so all-white is fine.
+    """
+    if count <= 0:
+        return []
+    import base64
+    import io as _io
+    from PIL import Image
+
+    w, h = _parse_image_size(size)
+    uris = []
+    for i in range(count):
+        img = Image.new("RGB", (w, h), (255, 255, 255))
+        # Stamp the index into the top-left pixel to make each image unique.
+        img.putpixel((0, 0), (i % 256, (i // 256) % 256, 254))
+        buf = _io.BytesIO()
+        img.save(buf, format="PNG")
+        b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+        uris.append(f"data:image/png;base64,{b64}")
+    return uris
+
+
 def _safe_mean(values):
     """Return the mean of values, or 0 if empty."""
     return float(np.mean(values)) if values else 0
@@ -267,9 +306,20 @@ async def single_request(session: aiohttp.ClientSession, api_base: str, model: s
     lora_name = request_data.get("lora_name")
     model_str = f"{model}:{lora_name}" if lora_name else model
 
+    # Multimodal: when the request carries images, send OpenAI content parts
+    # (text + image_url data URIs); otherwise a plain string (unchanged path).
+    prompt = request_data["prompt"]
+    images = request_data.get("images")
+    if images:
+        message_content = ([{"type": "text", "text": prompt}] if prompt else []) + [
+            {"type": "image_url", "image_url": {"url": u}} for u in images
+        ]
+    else:
+        message_content = prompt
+
     payload = {
         "model": model_str,
-        "messages": [{"role": "user", "content": request_data["prompt"]}],
+        "messages": [{"role": "user", "content": message_content}],
         "max_tokens": request_data["max_tokens"],
         "temperature": temperature,
         "stream": stream,
@@ -782,7 +832,8 @@ def calculate_stats(runs_data: List[Dict], steady_state_threshold: float = 0.8,
 
 
 def warmup_server(api_base: str, model: str, temperature: float, timeout: int,
-                  text_sampler, num_warmup_runs: int = 3, api_key: str = "dummy-key"):
+                  text_sampler, num_warmup_runs: int = 3, api_key: str = "dummy-key",
+                  image_uris: Optional[List[str]] = None):
     """Perform warmup runs to prepare the server before benchmarking."""
     print(f"Performing {num_warmup_runs} warmup runs...", end="", flush=True)
 
@@ -796,6 +847,8 @@ def warmup_server(api_base: str, model: str, temperature: float, timeout: int,
                     "prompt": req.prompt,
                     "max_tokens": max(1, min(4096, int(req.target_output_tokens))),
                 }
+                if image_uris:
+                    warmup_data["images"] = image_uris
                 try:
                     await single_request(session, api_base, model, warmup_data, temperature, timeout, api_key)
                 except Exception:
@@ -834,6 +887,10 @@ def main():
     parser.add_argument("--max-tokens", type=int, default=4096, help="Upper bound on max_tokens per request (default: 4096)")
     parser.add_argument("--ignore-eos", action="store_true", help="Ignore EOS and generate exactly max_tokens per request (SGLang/vLLM; a no-op on servers that don't support it). Fixes output length for clean throughput comparison.")
     parser.add_argument("-n", "--num-completions", type=int, default=1, help="Number of completions per request (default: 1)")
+
+    # Vision/multimodal: attach synthetic white images to every request
+    parser.add_argument("--num-images", type=int, default=0, help="Attach this many synthetic (white) images to each request. 0 = text-only (default).")
+    parser.add_argument("--image-size", type=str, default="512", help="Synthetic image size as N (square) or WxH, e.g. 512 or 1024x768 (default: 512). Only used when --num-images > 0.")
     parser.add_argument("--stream", action="store_true", help="Enable streaming (for TTFT/per-token metrics, lower throughput)")
     parser.add_argument("--description", default="Benchmark", help="Description of the benchmark")
     
@@ -908,6 +965,11 @@ def main():
         except Exception:
             return int(len(text.split()) * 1.3)
 
+    # Synthetic images (built once; content-independent, so shared by every request)
+    image_uris = build_synthetic_image_uris(args.image_size, args.num_images)
+    if image_uris:
+        print(f"🖼️  Attaching {args.num_images} synthetic image(s) of size {args.image_size} to each request")
+
     if args.replay_dataset:
         print(f"📊 Initialized benchmark in dataset-replay mode (max_tokens={args.max_tokens})")
     else:
@@ -925,6 +987,8 @@ def main():
         "scenario": args.scenario,
         "prompt_source": "dataset_replay" if args.replay_dataset else "scenario",
         "max_tokens": args.max_tokens,
+        "num_images": args.num_images,
+        "image_size": args.image_size if args.num_images > 0 else None,
         "dataset_config": dataset_config.config,
         "api_base": args.api_base,
         "execution_mode": execution_mode,
@@ -972,7 +1036,8 @@ def main():
         warmup_seed = derive_seed(args.seed, sweep_value, -1)
         with use_seed(warmup_seed):
             warmup_server(args.api_base, args.model, args.temperature, args.timeout,
-                         text_sampler, args.warmup_runs, api_key=args.api_key)
+                         text_sampler, args.warmup_runs, api_key=args.api_key,
+                         image_uris=image_uris)
 
         runs_data = []
         for run_idx in range(args.num_runs):
@@ -1000,6 +1065,8 @@ def main():
                     request_dict["lora_name"] = lora_assignments[idx]
                 if args.ignore_eos:
                     request_dict["ignore_eos"] = True
+                if image_uris:
+                    request_dict["images"] = image_uris
                 user_requests.append(request_dict)
 
             run_data = run_benchmark_batch(

--- a/tokenomics/completion_benchmark.py
+++ b/tokenomics/completion_benchmark.py
@@ -852,7 +852,7 @@ def main():
     # Vision/multimodal: attach synthetic random-noise images to every request
     parser.add_argument("--num-images", type=int, default=0, help="Attach this many synthetic (random-noise) images to each request. 0 = text-only (default).")
     parser.add_argument("--image-size", type=str, default="512", help="Synthetic image size as N (square) or WxH, e.g. 512 or 1024x768 (default: 512). Only used when --num-images > 0.")
-    parser.add_argument("--input-tokens", type=int, default=32, help="Length of the deterministic filler text for image runs when --scenario is not given (default: 32; 0 = images only).")
+    parser.add_argument("--input-tokens", type=int, default=None, help="Length of the deterministic filler text for image runs (default: 32; 0 = images only). Mutually exclusive with --scenario.")
     parser.add_argument("--stream", action="store_true", help="Enable streaming (for TTFT/per-token metrics, lower throughput)")
     parser.add_argument("--description", default="Benchmark", help="Description of the benchmark")
     
@@ -891,11 +891,18 @@ def main():
     elif args.scenario is None and args.num_images == 0:
         parser.error("--scenario is required unless --replay-dataset or --num-images is set")
 
+    # --scenario and --input-tokens both set the text length, two different ways.
+    if args.scenario is not None and args.input_tokens is not None:
+        parser.error("--input-tokens and --scenario are mutually exclusive (both set text length); "
+                     "--scenario drives text via its input value, --input-tokens is for image runs without --scenario")
+
     # Image runs default to short output (the text is just padding and the
     # images dominate): 32 tokens vs 4096 for text-only. Temperature is not
     # mode-dependent — pass --temperature 0 / --ignore-eos for reproducibility.
     if args.max_tokens is None:
         args.max_tokens = 32 if args.num_images > 0 else 4096
+    if args.input_tokens is None:
+        args.input_tokens = 32
 
     # Create LoRA config from command-line arguments
     lora_config = None

--- a/tokenomics/completion_benchmark.py
+++ b/tokenomics/completion_benchmark.py
@@ -819,6 +819,49 @@ def warmup_server(api_base: str, model: str, temperature: float, timeout: int,
     print(" done")
 
 
+def build_prompt_source(args):
+    """Resolve the prompt source and build the sampler (+ dataset/scenario).
+
+    Returns ``(prompt_source, text_sampler, scenario, dataset_loader,
+    dataset_config)`` where ``prompt_source`` is one of ``dataset_replay``,
+    ``fixed_filler`` (image runs without an explicit --scenario), or
+    ``scenario``. Centralizes the mode decision so the rest of main() reads one
+    value instead of re-deriving the condition.
+    """
+    if args.replay_dataset:
+        prompt_source = "dataset_replay"
+    elif args.num_images > 0 and args.scenario is None:
+        prompt_source = "fixed_filler"
+    else:
+        prompt_source = "scenario"
+
+    scenario = Scenario.from_string(args.scenario) if prompt_source == "scenario" else None
+
+    # Fixed-filler runs need no dataset; the others load one (default: AIME).
+    dataset_config = None
+    dataset_loader = None
+    if prompt_source != "fixed_filler":
+        if args.dataset_config is None:
+            from tokenomics import EXAMPLES_DIR
+            args.dataset_config = str(EXAMPLES_DIR / "dataset_configs" / "aime_simple.json")
+        dataset_config = DatasetConfig.from_file(args.dataset_config)
+        # Replay walks the first --num-prompts rows, so cap loading there (avoids
+        # encoding a whole large vision dataset). Scenario mode samples randomly
+        # and keeps the full dataset.
+        limit = args.num_prompts if prompt_source == "dataset_replay" else None
+        dataset_loader = DatasetLoader(dataset_config, limit=limit)
+
+    tokenizer_name = args.tokenizer or args.model
+    if prompt_source == "dataset_replay":
+        text_sampler = DatasetReplaySampler(tokenizer_name, dataset_loader, args.max_tokens)
+    elif prompt_source == "fixed_filler":
+        text_sampler = FixedFillerSampler(tokenizer_name, args.input_tokens, args.max_tokens)
+    else:
+        text_sampler = TextSampler(tokenizer_name, dataset_loader)
+
+    return prompt_source, text_sampler, scenario, dataset_loader, dataset_config
+
+
 def main():
     """Main function to run the enhanced benchmark."""
     parser = argparse.ArgumentParser(description="OAI server benchmark with scenario-based sampling")
@@ -916,33 +959,7 @@ def main():
         )
         print(f"🔧 LoRA config: strategy={lora_config.strategy}, {len(lora_config.lora_names)} LoRAs, base_model_ratio={lora_config.base_model_ratio}")
 
-    # Image runs with no explicit --scenario use a deterministic fixed filler
-    # (no dataset needed); a given --scenario still routes through TextSampler.
-    use_filler = args.num_images > 0 and args.scenario is None and not args.replay_dataset
-
-    # Initialize scenario and dataset
-    scenario = None if (args.replay_dataset or use_filler) else Scenario.from_string(args.scenario)
-    dataset_config = None
-    dataset_loader = None
-    if not use_filler:
-        if args.dataset_config is None:
-            from tokenomics import EXAMPLES_DIR
-            args.dataset_config = str(EXAMPLES_DIR / "dataset_configs" / "aime_simple.json")
-        dataset_config = DatasetConfig.from_file(args.dataset_config)
-        # In replay mode we walk the first --num-prompts rows, so cap loading
-        # there (avoids encoding a whole large vision dataset). Scenario mode
-        # samples randomly and keeps the full dataset.
-        loader_limit = args.num_prompts if args.replay_dataset else None
-        dataset_loader = DatasetLoader(dataset_config, limit=loader_limit)
-
-    tokenizer_name = args.tokenizer or args.model
-
-    if args.replay_dataset:
-        text_sampler = DatasetReplaySampler(tokenizer_name, dataset_loader, args.max_tokens)
-    elif use_filler:
-        text_sampler = FixedFillerSampler(tokenizer_name, args.input_tokens, args.max_tokens)
-    else:
-        text_sampler = TextSampler(tokenizer_name, dataset_loader)
+    prompt_source, text_sampler, scenario, dataset_loader, dataset_config = build_prompt_source(args)
 
     def count_output_tokens(text: str) -> int:
         """Client-side output-token count used when the server omits usage."""
@@ -951,12 +968,12 @@ def main():
     if args.num_images > 0:
         print(f"🖼️  Attaching {args.num_images} synthetic image(s) of size {args.image_size} to each request (unique per request)")
 
-    if args.replay_dataset:
-        print(f"📊 Initialized benchmark in dataset-replay mode (max_tokens={args.max_tokens})")
-    elif use_filler:
-        print(f"📊 Initialized benchmark with fixed filler ({args.input_tokens} input tokens, max_tokens={args.max_tokens}, temperature={args.temperature})")
-    else:
-        print(f"📊 Initialized benchmark with scenario: {args.scenario}")
+    source_msg = {
+        "dataset_replay": f"dataset-replay mode (max_tokens={args.max_tokens})",
+        "fixed_filler": f"fixed filler ({args.input_tokens} input tokens, max_tokens={args.max_tokens}, temperature={args.temperature})",
+        "scenario": f"scenario: {args.scenario}",
+    }[prompt_source]
+    print(f"📊 Initialized benchmark with {source_msg}")
     if dataset_loader is not None:
         print(f"📚 Loaded dataset: {len(dataset_loader)} samples")
     print(f"⚙️  Execution mode: {execution_mode}")
@@ -969,11 +986,11 @@ def main():
         "timestamp": datetime.now().isoformat(),
         "model": args.model,
         "scenario": args.scenario,
-        "prompt_source": "dataset_replay" if args.replay_dataset else ("fixed_filler" if use_filler else "scenario"),
+        "prompt_source": prompt_source,
         "max_tokens": args.max_tokens,
         "num_images": args.num_images,
         "image_size": args.image_size if args.num_images > 0 else None,
-        "input_tokens": args.input_tokens if use_filler else None,
+        "input_tokens": args.input_tokens if prompt_source == "fixed_filler" else None,
         "dataset_config": dataset_config.config if dataset_config is not None else None,
         "api_base": args.api_base,
         "execution_mode": execution_mode,

--- a/tokenomics/completion_benchmark.py
+++ b/tokenomics/completion_benchmark.py
@@ -929,7 +929,11 @@ def main():
             from tokenomics import EXAMPLES_DIR
             args.dataset_config = str(EXAMPLES_DIR / "dataset_configs" / "aime_simple.json")
         dataset_config = DatasetConfig.from_file(args.dataset_config)
-        dataset_loader = DatasetLoader(dataset_config)
+        # In replay mode we walk the first --num-prompts rows, so cap loading
+        # there (avoids encoding a whole large vision dataset). Scenario mode
+        # samples randomly and keeps the full dataset.
+        loader_limit = args.num_prompts if args.replay_dataset else None
+        dataset_loader = DatasetLoader(dataset_config, limit=loader_limit)
 
     tokenizer_name = args.tokenizer or args.model
 

--- a/tokenomics/completion_benchmark.py
+++ b/tokenomics/completion_benchmark.py
@@ -1059,7 +1059,10 @@ def main():
                     request_dict["lora_name"] = lora_assignments[idx]
                 if args.ignore_eos:
                     request_dict["ignore_eos"] = True
-                if args.num_images > 0:
+                if request.images:
+                    # Real images from a vision replay dataset (already unique).
+                    request_dict["images"] = request.images
+                elif args.num_images > 0:
                     uid = req_uid
                     req_uid += 1
                     # Unique text prefix + unique images so each request is a

--- a/tokenomics/completion_benchmark.py
+++ b/tokenomics/completion_benchmark.py
@@ -40,31 +40,30 @@ def _parse_image_size(spec: str) -> tuple:
 
 
 def build_synthetic_image_uris(size: str, count: int, start_id: int = 0) -> List[str]:
-    """Return `count` white PNG images (as base64 ``data:`` URIs) of the given size.
+    """Return `count` random-noise PNG images (as base64 ``data:`` URIs).
 
-    Each image is stamped with a unique 32-bit id (``start_id + k``, across four
-    pixels) so every image hashes differently — preventing the server's
-    multimodal cache from deduplicating identical images and undercounting the
-    vision-encoder compute. Callers pass a per-request ``start_id`` so images are
-    unique across the whole benchmark, not just within one request. Image
-    *content* is otherwise irrelevant to VL model speed, so all-white is fine.
+    Each image is filled with random pixels seeded by a unique id (``start_id +
+    k``), so it is deterministic (reproducible across runs) yet unique across the
+    whole benchmark — which keeps the server's prefix and multimodal caches from
+    deduplicating requests and undercounting vision-encoder compute. Pixel
+    *content* doesn't change VL compute (patch count is fixed by size), but note
+    noise is nearly incompressible, so payloads are much larger than a flat
+    image (~MBs at 1024x1024) — keep image size/count sane for the transport.
     """
     if count <= 0:
         return []
     import base64
     import io as _io
+    import numpy as np
     from PIL import Image
 
     w, h = _parse_image_size(size)
     uris = []
     for k in range(count):
-        uid = start_id + k
-        img = Image.new("RGB", (w, h), (255, 255, 255))
-        for px in range(4):  # encode uid over 4 pixels -> 2^32 distinct images
-            b = (uid >> (8 * px)) & 0xFF
-            img.putpixel((px, 0), (b, b, b))
+        rng = np.random.default_rng(start_id + k)  # deterministic, unique per image
+        arr = rng.integers(0, 256, size=(h, w, 3), dtype=np.uint8)
         buf = _io.BytesIO()
-        img.save(buf, format="PNG")
+        Image.fromarray(arr, "RGB").save(buf, format="PNG")
         b64 = base64.b64encode(buf.getvalue()).decode("ascii")
         uris.append(f"data:image/png;base64,{b64}")
     return uris
@@ -892,8 +891,8 @@ def main():
     parser.add_argument("--ignore-eos", action="store_true", help="Ignore EOS and generate exactly max_tokens per request (SGLang/vLLM; a no-op on servers that don't support it). Fixes output length for clean throughput comparison.")
     parser.add_argument("-n", "--num-completions", type=int, default=1, help="Number of completions per request (default: 1)")
 
-    # Vision/multimodal: attach synthetic white images to every request
-    parser.add_argument("--num-images", type=int, default=0, help="Attach this many synthetic (white) images to each request. 0 = text-only (default).")
+    # Vision/multimodal: attach synthetic random-noise images to every request
+    parser.add_argument("--num-images", type=int, default=0, help="Attach this many synthetic (random-noise) images to each request. 0 = text-only (default).")
     parser.add_argument("--image-size", type=str, default="512", help="Synthetic image size as N (square) or WxH, e.g. 512 or 1024x768 (default: 512). Only used when --num-images > 0.")
     parser.add_argument("--input-tokens", type=int, default=32, help="Length of the deterministic filler text for image runs when --scenario is not given (default: 32; 0 = images only).")
     parser.add_argument("--stream", action="store_true", help="Enable streaming (for TTFT/per-token metrics, lower throughput)")

--- a/tokenomics/plot_completion_benchmark.py
+++ b/tokenomics/plot_completion_benchmark.py
@@ -72,6 +72,15 @@ def generate_label_from_metadata(metadata: Dict, json_file: str) -> str:
     if "baseline" in desc.lower() or "no lora" in desc.lower():
         return "Baseline (No LoRA)"
 
+    # Image runs self-label by shape (count/size/filler length) when no custom
+    # --description was given, so overlaid VL configs are distinguishable.
+    num_images = metadata.get("num_images", 0)
+    if num_images and desc in ("", "Benchmark"):
+        label = f"{num_images}img@{metadata.get('image_size')}"
+        if metadata.get("input_tokens") is not None:
+            label += f" {metadata['input_tokens']}tok"
+        return label
+
     return desc or Path(json_file).stem
 
 

--- a/tokenomics/sampling/__init__.py
+++ b/tokenomics/sampling/__init__.py
@@ -8,6 +8,7 @@ statistical parameter generation from content sampling.
 from .scenarios import Scenario, NormalDistribution, DeterministicDistribution, UniformDistribution
 from .sampler import TextSampler, DatasetReplaySampler, FixedFillerSampler, UserRequest, use_seed, derive_seed
 from .dataset import DatasetConfig, DatasetLoader
+from .images import build_synthetic_image_uris, parse_image_size
 
 __all__ = [
     'Scenario',
@@ -21,5 +22,7 @@ __all__ = [
     'use_seed',
     'derive_seed',
     'DatasetConfig',
-    'DatasetLoader'
+    'DatasetLoader',
+    'build_synthetic_image_uris',
+    'parse_image_size',
 ]

--- a/tokenomics/sampling/__init__.py
+++ b/tokenomics/sampling/__init__.py
@@ -6,7 +6,7 @@ statistical parameter generation from content sampling.
 """
 
 from .scenarios import Scenario, NormalDistribution, DeterministicDistribution, UniformDistribution
-from .sampler import TextSampler, DatasetReplaySampler, UserRequest, use_seed, derive_seed
+from .sampler import TextSampler, DatasetReplaySampler, FixedFillerSampler, UserRequest, use_seed, derive_seed
 from .dataset import DatasetConfig, DatasetLoader
 
 __all__ = [
@@ -16,6 +16,7 @@ __all__ = [
     'UniformDistribution',
     'TextSampler',
     'DatasetReplaySampler',
+    'FixedFillerSampler',
     'UserRequest',
     'use_seed',
     'derive_seed',

--- a/tokenomics/sampling/__init__.py
+++ b/tokenomics/sampling/__init__.py
@@ -6,7 +6,7 @@ statistical parameter generation from content sampling.
 """
 
 from .scenarios import Scenario, NormalDistribution, DeterministicDistribution, UniformDistribution
-from .sampler import TextSampler, DatasetReplaySampler, FixedFillerSampler, UserRequest, use_seed, derive_seed
+from .sampler import TextSampler, DatasetReplaySampler, FixedFillerSampler, UserRequest, use_seed, derive_seed, count_tokens
 from .dataset import DatasetConfig, DatasetLoader
 from .images import build_synthetic_image_uris, parse_image_size
 
@@ -21,6 +21,7 @@ __all__ = [
     'UserRequest',
     'use_seed',
     'derive_seed',
+    'count_tokens',
     'DatasetConfig',
     'DatasetLoader',
     'build_synthetic_image_uris',

--- a/tokenomics/sampling/dataset.py
+++ b/tokenomics/sampling/dataset.py
@@ -41,6 +41,8 @@ class DatasetConfig:
         self.source_type = config_dict.get("source", {}).get("type", "file")
         self.source_path = config_dict.get("source", {}).get("path", "")
         self.prompt_column = config_dict.get("prompt_column", "text")
+        # Optional image column for multimodal (VL) replay datasets.
+        self.image_column = config_dict.get("image_column")
 
     @classmethod
     def from_file(cls, config_path: str) -> "DatasetConfig":
@@ -62,6 +64,8 @@ class DatasetLoader:
     def __init__(self, config: DatasetConfig):
         self.config = config
         self.data: List[str] = []
+        # Per-row image data URIs, aligned with self.data (empty for text datasets).
+        self.images: List[List[str]] = []
         self._load_data()
     
     def _load_data(self) -> None:
@@ -138,11 +142,17 @@ class DatasetLoader:
             else:
                 data_split = dataset
 
+            img_col = self.config.image_column
+            if img_col:
+                from .images import image_value_to_uris
             for item in data_split:
                 if self.config.prompt_column in item:
                     text = _coerce_prompt(item[self.config.prompt_column])
-                    if text:
-                        self.data.append(text)
+                    if not text and not img_col:
+                        continue
+                    self.data.append(text)
+                    if img_col:
+                        self.images.append(image_value_to_uris(item.get(img_col)))
 
         except Exception as e:
             raise RuntimeError(f"Failed to load HuggingFace dataset: {e}")
@@ -168,7 +178,11 @@ class DatasetLoader:
     def get_all_texts(self) -> List[str]:
         """Get all texts from the dataset."""
         return self.data.copy()
-    
+
+    def get_all_images(self) -> List[List[str]]:
+        """Per-row image ``data:`` URIs, aligned with get_all_texts (empty if none)."""
+        return self.images.copy()
+
     def __len__(self) -> int:
         """Return the number of samples in the dataset."""
         return len(self.data)

--- a/tokenomics/sampling/dataset.py
+++ b/tokenomics/sampling/dataset.py
@@ -7,6 +7,7 @@ to work with the scenario-based parameter generation.
 
 import json
 import csv
+import itertools
 import random
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Union
@@ -61,12 +62,19 @@ class DatasetConfig:
 class DatasetLoader:
     """Loads and manages dataset content for sampling."""
     
-    def __init__(self, config: DatasetConfig):
+    def __init__(self, config: DatasetConfig, limit: Optional[int] = None):
         self.config = config
+        # Stop after `limit` rows instead of materializing the whole dataset —
+        # avoids eagerly base64-encoding every image of a large vision dataset
+        # when the run only replays the first N rows. None = load everything.
+        self.limit = limit
         self.data: List[str] = []
         # Per-row image data URIs, aligned with self.data (empty for text datasets).
         self.images: List[List[str]] = []
         self._load_data()
+
+    def _reached_limit(self) -> bool:
+        return self.limit is not None and len(self.data) >= self.limit
     
     def _load_data(self) -> None:
         """Load data based on configuration."""
@@ -102,23 +110,31 @@ class DatasetLoader:
             for row in reader:
                 if self.config.prompt_column in row:
                     self.data.append(row[self.config.prompt_column])
-    
+                    if self._reached_limit():
+                        break
+
     def _load_from_json(self, file_path: Path) -> None:
         """Load data from JSON file."""
         with open(file_path, 'r', encoding='utf-8') as f:
             data = json.load(f)
-        
+
         if isinstance(data, list):
             for item in data:
                 if isinstance(item, dict) and self.config.prompt_column in item:
                     self.data.append(item[self.config.prompt_column])
                 elif isinstance(item, str):
                     self.data.append(item)
-    
+                if self._reached_limit():
+                    break
+
     def _load_from_text(self, file_path: Path) -> None:
         """Load data from text file (one line per sample)."""
         with open(file_path, 'r', encoding='utf-8') as f:
-            self.data = [line.strip() for line in f if line.strip()]
+            lines = (line.strip() for line in f if line.strip())
+            if self.limit is not None:
+                self.data = list(itertools.islice(lines, self.limit))
+            else:
+                self.data = list(lines)
     
     def _load_from_huggingface(self) -> None:
         """Load data from HuggingFace dataset."""
@@ -153,6 +169,8 @@ class DatasetLoader:
                     self.data.append(text)
                     if img_col:
                         self.images.append(image_value_to_uris(item.get(img_col)))
+                    if self._reached_limit():
+                        break
 
         except Exception as e:
             raise RuntimeError(f"Failed to load HuggingFace dataset: {e}")
@@ -165,6 +183,8 @@ class DatasetLoader:
                 # Create a system + user prompt like in the original
                 prompt = f"You are an assistant that helps students solve challenging problems.\n\n{item['Question']}"
                 self.data.append(prompt)
+                if self._reached_limit():
+                    break
         except Exception as e:
             raise RuntimeError(f"Failed to load AIME dataset: {e}")
     

--- a/tokenomics/sampling/images.py
+++ b/tokenomics/sampling/images.py
@@ -8,10 +8,47 @@ form of synthetic request content.
 
 import base64
 import io
-from typing import List, Tuple
+import os
+from typing import Any, List, Optional, Tuple
 
 import numpy as np
 from PIL import Image
+
+
+def _pil_to_uri(img: "Image.Image") -> str:
+    buf = io.BytesIO()
+    img.convert("RGB").save(buf, format="PNG")
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def image_value_to_uris(value: Any) -> List[str]:
+    """Coerce a dataset image-column value into a list of ``data:`` URIs.
+
+    Handles the shapes HuggingFace vision datasets produce: a decoded PIL image,
+    a ``{"bytes"/"path"}`` dict, a filesystem path, or a list of any of these
+    (multi-image rows). Unrecognized/empty values yield an empty list.
+    """
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        out: List[str] = []
+        for v in value:
+            out.extend(image_value_to_uris(v))
+        return out
+    # Decoded PIL image (the common HF Image-feature case)
+    if hasattr(value, "save"):
+        return [_pil_to_uri(value)]
+    # HF Image dict: {"bytes": ..., "path": ...}
+    if isinstance(value, dict):
+        if value.get("bytes"):
+            return [_pil_to_uri(Image.open(io.BytesIO(value["bytes"])))]
+        if value.get("path") and os.path.exists(value["path"]):
+            return [_pil_to_uri(Image.open(value["path"]))]
+        return []
+    # Filesystem path
+    if isinstance(value, str) and os.path.exists(value):
+        return [_pil_to_uri(Image.open(value))]
+    return []
 
 
 def parse_image_size(spec: str) -> Tuple[int, int]:

--- a/tokenomics/sampling/images.py
+++ b/tokenomics/sampling/images.py
@@ -1,0 +1,51 @@
+"""
+Synthetic image generation for multimodal (VL) benchmarking.
+
+Produces images as OpenAI ``image_url`` base64 ``data:`` URIs, so any completion
+request can carry them. Kept alongside the text samplers since it's just another
+form of synthetic request content.
+"""
+
+import base64
+import io
+from typing import List, Tuple
+
+import numpy as np
+from PIL import Image
+
+
+def parse_image_size(spec: str) -> Tuple[int, int]:
+    """Parse an image size spec: '512' -> (512, 512), '640x480' -> (640, 480)."""
+    parts = str(spec).lower().split("x")
+    if len(parts) == 1:
+        w = h = int(parts[0])
+    elif len(parts) == 2:
+        w, h = int(parts[0]), int(parts[1])
+    else:
+        raise ValueError(f"Invalid image size '{spec}'; use N or WxH")
+    return w, h
+
+
+def build_synthetic_image_uris(size: str, count: int, start_id: int = 0) -> List[str]:
+    """Return `count` random-noise PNG images (as base64 ``data:`` URIs).
+
+    Each image is filled with random pixels seeded by a unique id (``start_id +
+    k``), so it is deterministic (reproducible across runs) yet unique across the
+    whole benchmark — which keeps the server's prefix and multimodal caches from
+    deduplicating requests and undercounting vision-encoder compute. Pixel
+    *content* doesn't change VL compute (patch count is fixed by size), but note
+    noise is nearly incompressible, so payloads are much larger than a flat
+    image (~MBs at 1024x1024) — keep image size/count sane for the transport.
+    """
+    if count <= 0:
+        return []
+    w, h = parse_image_size(size)
+    uris = []
+    for k in range(count):
+        rng = np.random.default_rng(start_id + k)  # deterministic, unique per image
+        arr = rng.integers(0, 256, size=(h, w, 3), dtype=np.uint8)
+        buf = io.BytesIO()
+        Image.fromarray(arr, "RGB").save(buf, format="PNG")
+        b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+        uris.append(f"data:image/png;base64,{b64}")
+    return uris

--- a/tokenomics/sampling/sampler.py
+++ b/tokenomics/sampling/sampler.py
@@ -3,7 +3,6 @@ Text sampler that combines statistical scenarios with dataset content.
 """
 
 import random
-import warnings
 import hashlib
 import contextlib
 import numpy as np
@@ -12,6 +11,14 @@ from tokenizers import Tokenizer
 
 from .scenarios import Scenario
 from .dataset import DatasetLoader
+
+
+def count_tokens(tokenizer: Tokenizer, text: str) -> int:
+    """Token count for ``text``, with a rough word-based fallback on failure."""
+    try:
+        return len(tokenizer.encode(text, add_special_tokens=True).ids)
+    except Exception:
+        return int(len(text.split()) * 1.3)
 
 
 class UserRequest(NamedTuple):
@@ -34,7 +41,7 @@ class TextSampler:
         print(f"Pre-tokenizing {len(dataset_loader)} dataset texts...")
         t0 = time.time()
         self.text_token_cache = [
-            (text, self._count_tokens(text))
+            (text, count_tokens(self.tokenizer, text))
             for text in dataset_loader.get_all_texts()
         ]
         total_tokens = sum(count for _, count in self.text_token_cache)
@@ -67,13 +74,6 @@ class TextSampler:
 
         return " ".join(texts), current_tokens
 
-    def _count_tokens(self, text: str) -> int:
-        """Count tokens in text using the tokenizer."""
-        try:
-            return len(self.tokenizer.encode(text, add_special_tokens=True).ids)
-        except Exception:
-            return int(len(text.split()) * 1.3)
-
 
 class DatasetReplaySampler:
     """Sends each dataset row verbatim as one request, walking the dataset in order.
@@ -96,12 +96,6 @@ class DatasetReplaySampler:
         if not self.rows:
             raise ValueError("Dataset is empty")
 
-    def _count_tokens(self, text: str) -> int:
-        try:
-            return len(self.tokenizer.encode(text, add_special_tokens=True).ids)
-        except Exception:
-            return int(len(text.split()) * 1.3)
-
     def sample_batch(self, scenario: Scenario, batch_size: int) -> List[UserRequest]:
         """Return the first ``batch_size`` rows verbatim, in dataset order.
 
@@ -116,7 +110,7 @@ class DatasetReplaySampler:
         out = []
         for i in range(min(batch_size, len(self.rows))):
             text = self.rows[i]
-            n_tok = self._count_tokens(text)
+            n_tok = count_tokens(self.tokenizer, text)
             imgs = self.images[i] if i < len(self.images) else None
             out.append(UserRequest(text, self.max_tokens, n_tok, n_tok, self.max_tokens, imgs))
         return out
@@ -147,14 +141,8 @@ class FixedFillerSampler:
             ids = ids + ids
         return self.tokenizer.decode(ids[:n_tokens])
 
-    def _count_tokens(self, text: str) -> int:
-        try:
-            return len(self.tokenizer.encode(text, add_special_tokens=True).ids)
-        except Exception:
-            return int(len(text.split()) * 1.3)
-
     def sample_batch(self, scenario: Scenario, batch_size: int) -> List[UserRequest]:
-        it = self._count_tokens(self.prompt) if self.prompt else 0
+        it = count_tokens(self.tokenizer, self.prompt) if self.prompt else 0
         return [UserRequest(self.prompt, self.max_tokens, it, it, self.max_tokens)
                 for _ in range(batch_size)]
 

--- a/tokenomics/sampling/sampler.py
+++ b/tokenomics/sampling/sampler.py
@@ -119,6 +119,43 @@ class DatasetReplaySampler:
         return out
 
 
+class FixedFillerSampler:
+    """Deterministic fixed-length filler text, same base prompt for every request.
+
+    For image/VL runs the text is just padding to a target input length and its
+    content doesn't affect speed, so we use a reproducible fixed filler of
+    ~``input_tokens`` tokens (0 -> empty). The benchmark loop makes each request
+    unique (it prefixes a request id) to avoid server-side prefix caching, so the
+    identical base prompt here is fine. Same ``sample_batch`` / ``tokenizer``
+    surface as :class:`TextSampler`, so it is a drop-in replacement.
+    """
+
+    def __init__(self, tokenizer_name: str, input_tokens: int, max_tokens: int):
+        self.tokenizer = Tokenizer.from_pretrained(tokenizer_name)
+        self.max_tokens = max_tokens
+        self.prompt = self._build_filler(input_tokens)
+
+    def _build_filler(self, n_tokens: int) -> str:
+        if n_tokens <= 0:
+            return ""
+        seed_text = "The quick brown fox jumps over the lazy dog. "
+        ids = self.tokenizer.encode(seed_text * (n_tokens // 8 + 2), add_special_tokens=False).ids
+        while len(ids) < n_tokens:
+            ids = ids + ids
+        return self.tokenizer.decode(ids[:n_tokens])
+
+    def _count_tokens(self, text: str) -> int:
+        try:
+            return len(self.tokenizer.encode(text, add_special_tokens=True).ids)
+        except Exception:
+            return int(len(text.split()) * 1.3)
+
+    def sample_batch(self, scenario: Scenario, batch_size: int) -> List[UserRequest]:
+        it = self._count_tokens(self.prompt) if self.prompt else 0
+        return [UserRequest(self.prompt, self.max_tokens, it, it, self.max_tokens)
+                for _ in range(batch_size)]
+
+
 @contextlib.contextmanager
 def use_seed(seed: int):
     state = random.getstate()

--- a/tokenomics/sampling/sampler.py
+++ b/tokenomics/sampling/sampler.py
@@ -7,7 +7,7 @@ import warnings
 import hashlib
 import contextlib
 import numpy as np
-from typing import List, NamedTuple
+from typing import List, NamedTuple, Optional
 from tokenizers import Tokenizer
 
 from .scenarios import Scenario
@@ -20,6 +20,7 @@ class UserRequest(NamedTuple):
     actual_input_tokens: int
     target_input_tokens: int
     target_output_tokens: int
+    images: Optional[List[str]] = None  # per-request image data URIs (VL replay)
 
 
 class TextSampler:
@@ -91,6 +92,7 @@ class DatasetReplaySampler:
         self.dataset_loader = dataset_loader
         self.max_tokens = max_tokens
         self.rows = dataset_loader.get_all_texts()
+        self.images = dataset_loader.get_all_images()  # [] for text-only datasets
         if not self.rows:
             raise ValueError("Dataset is empty")
 
@@ -115,7 +117,8 @@ class DatasetReplaySampler:
         for i in range(min(batch_size, len(self.rows))):
             text = self.rows[i]
             n_tok = self._count_tokens(text)
-            out.append(UserRequest(text, self.max_tokens, n_tok, n_tok, self.max_tokens))
+            imgs = self.images[i] if i < len(self.images) else None
+            out.append(UserRequest(text, self.max_tokens, n_tok, n_tok, self.max_tokens, imgs))
         return out
 
 


### PR DESCRIPTION
First phase of [TEC-481](https://linear.app/liquid-ai/issue/TEC-481/add-image-benchmark-to-tokenomics): VL inference-speed benchmarking, built into `completion` rather than a separate subcommand — **images are just another request-content dimension**.

## Usage

```bash
# minimal: 5 images per request, sweep concurrency (short deterministic defaults)
tokenomics completion --model your-vl-model \
  --num-images 5 --image-size 512 \
  --max-concurrency 1,2,4,8,16 --results-dir results/vl_512x5/
```

`--num-images N` (0 = text-only, unchanged) attaches images to every request as OpenAI content parts (`image_url` base64 `data:` URIs, accepted by SGLang and vLLM). Text length, output, concurrency, metrics, results JSON, and `plot-completion` are all the existing machinery — so the concurrency-vs-latency plot is just `plot-completion` over the run dirs.

## Defaults for image runs (short + deterministic)

When `--num-images > 0` and no `--scenario` is given, image runs use sane defaults (the images dominate; text is padding):

- **Input text**: a deterministic fixed filler of `--input-tokens` tokens (**default 32**; `0` = images only). Exact length, no dataset needed.
- **Output**: `--max-tokens` defaults to **32** (vs 4096 for text-only runs).
- **Decoding**: `--temperature` defaults to **0** (greedy) for image runs (vs 0.7).

All overridable. Passing an explicit `--scenario` instead routes text through the dataset sampler (images on top of realistic/replayed prompts).

## Determinism + cache-correctness

Every request is made **unique but reproducible** so the server's caches can't dedupe requests and undercount compute:

- **Images**: random-noise PNGs, each seeded by a per-request id → unique across the whole run, identical across re-runs. (Noise, not flat color, so there's nothing for a perceptual/hash cache to collapse.)
- **Text**: a per-request id prefix on the filler, so prompts are distinct even though the base filler is constant.

Request ids follow the fixed iteration order (no RNG), so a given invocation is fully reproducible. Warmup images use a disjoint id range so they don't cache-collide with measured requests.

## New flags

| Flag | Default | Meaning |
|------|---------|---------|
| `--num-images` | 0 | Images attached per request (0 = text-only) |
| `--image-size` | 512 | `N` or `WxH` |
| `--input-tokens` | 32 | Fixed-filler length for image runs w/o `--scenario` (0 = images only) |
| `--max-tokens` | 4096 / **32 img** | Output cap; defaults to 32 for image runs |
| `--temperature` | 0.7 / **0 img** | Defaults to 0 for image runs |

Implemented via a small drop-in `FixedFillerSampler` (exact-length deterministic filler, no dataset dependency).

## Sweeping = external composition

The image-size × count × input-length grid is **not** baked in — loop the command (one `--results-dir` each) and overlay with `plot-completion`. Keeps the tool general; the TEC-481 sweep is one caller.

## Caveat

Noise is nearly incompressible, so payloads are much larger than a flat image (~260 KB at 256², ~4.2 MB at 1024²). Keep image size/count modest or the request upload starts to dominate the measurement.

## Testing (mock OpenAI server, no GPU)
- Image run, no scenario → `fixed_filler (32 in, max_tokens=32, temp=0)`; content is `[text, image_url, …]`; all prompts and all images across the run unique.
- Text-only (`--num-images 0`) is byte-for-byte unchanged (string content, 4096/0.7).
- `--input-tokens 0` → images-only; non-square `WxH`; warmup + multi-point concurrency sweep; metadata records `prompt_source/num_images/image_size/input_tokens/max_tokens/temperature`.
- Noise images verified deterministic, unique per id, genuinely random.

Adds a `pillow` dependency (numpy already present). No changes to the request/metrics/plotting paths beyond the multimodal content branch.

## Follow-ups (not in this PR)
- Real vision datasets (`conversation` + image paths, e.g. `mmmu-upstream_v1`) as a multimodal dataset source — reuses the same per-request `images` slot.
- Optional `--image-content white|noise` / JPEG encoding if the noise payload size becomes limiting.